### PR TITLE
Add option to open folder recursively

### DIFF
--- a/quick-picture-viewer/MainForm.Designer.cs
+++ b/quick-picture-viewer/MainForm.Designer.cs
@@ -28,123 +28,125 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-			this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
-			this.fileSystemWatcher1 = new System.IO.FileSystemWatcher();
-			this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
-			this.statusStrip1 = new System.Windows.Forms.StatusStrip();
-			this.directoryLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.fileLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.sizeLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.zoomLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.hasChangesLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.dateCreatedLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.dateModifiedLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.printDialog1 = new System.Windows.Forms.PrintDialog();
-			this.printDocument1 = new System.Drawing.Printing.PrintDocument();
-			this.colorDialog1 = new System.Windows.Forms.ColorDialog();
-			this.toolStrip1 = new QuickLibrary.QlibToolbar();
-			this.openButton = new System.Windows.Forms.ToolStripButton();
-			this.saveAsButton = new System.Windows.Forms.ToolStripButton();
-			this.externalBtn = new System.Windows.Forms.ToolStripDropDownButton();
-			this.externalRunBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.externalFavoriteBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.externalChooseBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator4 = new QuickLibrary.QlibToolsep();
-			this.infoButton = new System.Windows.Forms.ToolStripButton();
-			this.prevButton = new System.Windows.Forms.ToolStripButton();
-			this.slideshowButton = new System.Windows.Forms.ToolStripButton();
-			this.nextButton = new System.Windows.Forms.ToolStripButton();
-			this.showFileButton = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator1 = new QuickLibrary.QlibToolsep();
-			this.autoZoomButton = new System.Windows.Forms.ToolStripButton();
-			this.zoomOutButton = new System.Windows.Forms.ToolStripButton();
-			this.zoomTextBox = new System.Windows.Forms.ToolStripTextBox();
-			this.zoomInButton = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator2 = new QuickLibrary.QlibToolsep();
-			this.editButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.flipHorizontalButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.flipVerticalButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator7 = new QuickLibrary.QlibToolsep();
-			this.rotateRightButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.rotateLeftButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.rotate180Button = new System.Windows.Forms.ToolStripMenuItem();
-			this.customAngleBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.copyButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.copyImageButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.copyFileBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.pasteButton = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator3 = new QuickLibrary.QlibToolsep();
-			this.checkboardButton = new System.Windows.Forms.ToolStripButton();
-			this.fullscreenBtn = new System.Windows.Forms.ToolStripButton();
-			this.miniViewButton = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator5 = new QuickLibrary.QlibToolsep();
-			this.effectsBtn = new System.Windows.Forms.ToolStripDropDownButton();
-			this.pluginManBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolsBtn = new System.Windows.Forms.ToolStripDropDownButton();
-			this.pluginManBtn2 = new System.Windows.Forms.ToolStripMenuItem();
-			this.qlibToolsep1 = new QuickLibrary.QlibToolsep();
-			this.moreButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.reloadButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.deleteBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.printButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.setAsDesktopButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.qlibMenuSeparator2 = new QuickLibrary.QlibToolsep();
-			this.actualSizeBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator9 = new QuickLibrary.QlibToolsep();
-			this.backColorBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.backClearBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.qlibMenuSeparator1 = new QuickLibrary.QlibToolsep();
-			this.backCustomBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.onTopButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.framelessBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.newWindowButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator10 = new QuickLibrary.QlibToolsep();
-			this.settingsButton = new System.Windows.Forms.ToolStripMenuItem();
-			this.aboutBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.framelessCloseBtn = new System.Windows.Forms.ToolStripButton();
-			this.picturePanel = new quick_picture_viewer.CustomPanel();
-			this.rmbMenu = new QuickLibrary.QlibContextMenuStrip(this.components);
-			this.showMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.showStatusBarBtn = new System.Windows.Forms.ToolStripMenuItem();
-			this.suggestionIcon = new System.Windows.Forms.PictureBox();
-			this.suggestionLabel = new System.Windows.Forms.Label();
-			this.pleaseOpenLabel = new System.Windows.Forms.Label();
-			this.pictureBox = new System.Windows.Forms.PictureBox();
-			this.typeOpsButton = new System.Windows.Forms.Button();
-			this.showToolbarBtn = new System.Windows.Forms.ToolStripMenuItem();
-			((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).BeginInit();
-			this.statusStrip1.SuspendLayout();
-			this.toolStrip1.SuspendLayout();
-			this.picturePanel.SuspendLayout();
-			this.rmbMenu.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.suggestionIcon)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// openFileDialog1
-			// 
-			this.openFileDialog1.FileName = "image";
-			resources.ApplyResources(this.openFileDialog1, "openFileDialog1");
-			this.openFileDialog1.RestoreDirectory = true;
-			// 
-			// fileSystemWatcher1
-			// 
-			this.fileSystemWatcher1.EnableRaisingEvents = true;
-			this.fileSystemWatcher1.SynchronizingObject = this;
-			// 
-			// saveFileDialog1
-			// 
-			this.saveFileDialog1.FileName = "Image";
-			resources.ApplyResources(this.saveFileDialog1, "saveFileDialog1");
-			// 
-			// statusStrip1
-			// 
-			this.statusStrip1.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.statusStrip1, "statusStrip1");
-			this.statusStrip1.GripMargin = new System.Windows.Forms.Padding(0);
-			this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
+            this.fileSystemWatcher1 = new System.IO.FileSystemWatcher();
+            this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.printDialog1 = new System.Windows.Forms.PrintDialog();
+            this.printDocument1 = new System.Drawing.Printing.PrintDocument();
+            this.colorDialog1 = new System.Windows.Forms.ColorDialog();
+            this.toolStrip1 = new QuickLibrary.QlibToolbar();
+            this.toolStripSeparator4 = new QuickLibrary.QlibToolsep();
+            this.toolStripSeparator1 = new QuickLibrary.QlibToolsep();
+            this.zoomTextBox = new System.Windows.Forms.ToolStripTextBox();
+            this.toolStripSeparator2 = new QuickLibrary.QlibToolsep();
+            this.toolStripSeparator3 = new QuickLibrary.QlibToolsep();
+            this.toolStripSeparator5 = new QuickLibrary.QlibToolsep();
+            this.qlibToolsep1 = new QuickLibrary.QlibToolsep();
+            this.rmbMenu = new QuickLibrary.QlibContextMenuStrip(this.components);
+            this.openFolderDialog1 = new System.Windows.Forms.FolderBrowserDialog();
+            this.picturePanel = new quick_picture_viewer.CustomPanel();
+            this.suggestionLabel = new System.Windows.Forms.Label();
+            this.pleaseOpenLabel = new System.Windows.Forms.Label();
+            this.typeOpsButton = new System.Windows.Forms.Button();
+            this.directoryLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.fileLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.sizeLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.zoomLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.hasChangesLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.dateCreatedLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.dateModifiedLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.openButton = new System.Windows.Forms.ToolStripButton();
+            this.openFolderButton = new System.Windows.Forms.ToolStripButton();
+            this.saveAsButton = new System.Windows.Forms.ToolStripButton();
+            this.externalBtn = new System.Windows.Forms.ToolStripDropDownButton();
+            this.externalRunBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.externalFavoriteBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.externalChooseBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.infoButton = new System.Windows.Forms.ToolStripButton();
+            this.prevButton = new System.Windows.Forms.ToolStripButton();
+            this.slideshowButton = new System.Windows.Forms.ToolStripButton();
+            this.nextButton = new System.Windows.Forms.ToolStripButton();
+            this.showFileButton = new System.Windows.Forms.ToolStripButton();
+            this.autoZoomButton = new System.Windows.Forms.ToolStripButton();
+            this.zoomOutButton = new System.Windows.Forms.ToolStripButton();
+            this.zoomInButton = new System.Windows.Forms.ToolStripButton();
+            this.editButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.flipHorizontalButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.flipVerticalButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator7 = new QuickLibrary.QlibToolsep();
+            this.rotateRightButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.rotateLeftButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.rotate180Button = new System.Windows.Forms.ToolStripMenuItem();
+            this.customAngleBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.copyImageButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyFileBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.pasteButton = new System.Windows.Forms.ToolStripButton();
+            this.checkboardButton = new System.Windows.Forms.ToolStripButton();
+            this.fullscreenBtn = new System.Windows.Forms.ToolStripButton();
+            this.miniViewButton = new System.Windows.Forms.ToolStripButton();
+            this.effectsBtn = new System.Windows.Forms.ToolStripDropDownButton();
+            this.pluginManBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolsBtn = new System.Windows.Forms.ToolStripDropDownButton();
+            this.pluginManBtn2 = new System.Windows.Forms.ToolStripMenuItem();
+            this.moreButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.reloadButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.printButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.setAsDesktopButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.qlibMenuSeparator2 = new QuickLibrary.QlibToolsep();
+            this.actualSizeBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator9 = new QuickLibrary.QlibToolsep();
+            this.backColorBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.backClearBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.qlibMenuSeparator1 = new QuickLibrary.QlibToolsep();
+            this.backCustomBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.onTopButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.framelessBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.newWindowButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator10 = new QuickLibrary.QlibToolsep();
+            this.settingsButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.aboutBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.framelessCloseBtn = new System.Windows.Forms.ToolStripButton();
+            this.showMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showToolbarBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.showStatusBarBtn = new System.Windows.Forms.ToolStripMenuItem();
+            this.suggestionIcon = new System.Windows.Forms.PictureBox();
+            this.pictureBox = new System.Windows.Forms.PictureBox();
+            ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).BeginInit();
+            this.statusStrip1.SuspendLayout();
+            this.toolStrip1.SuspendLayout();
+            this.rmbMenu.SuspendLayout();
+            this.picturePanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.suggestionIcon)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // openFileDialog1
+            // 
+            this.openFileDialog1.FileName = "image";
+            resources.ApplyResources(this.openFileDialog1, "openFileDialog1");
+            this.openFileDialog1.RestoreDirectory = true;
+            // 
+            // fileSystemWatcher1
+            // 
+            this.fileSystemWatcher1.EnableRaisingEvents = true;
+            this.fileSystemWatcher1.SynchronizingObject = this;
+            // 
+            // saveFileDialog1
+            // 
+            this.saveFileDialog1.FileName = "Image";
+            resources.ApplyResources(this.saveFileDialog1, "saveFileDialog1");
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.statusStrip1, "statusStrip1");
+            this.statusStrip1.GripMargin = new System.Windows.Forms.Padding(0);
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.directoryLabel,
             this.fileLabel,
             this.sizeLabel,
@@ -152,87 +154,39 @@
             this.hasChangesLabel,
             this.dateCreatedLabel,
             this.dateModifiedLabel});
-			this.statusStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
-			this.statusStrip1.Name = "statusStrip1";
-			this.statusStrip1.ShowItemToolTips = true;
-			this.statusStrip1.VisibleChanged += new System.EventHandler(this.statusStrip1_VisibleChanged);
-			// 
-			// directoryLabel
-			// 
-			this.directoryLabel.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.directoryLabel, "directoryLabel");
-			this.directoryLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
-			this.directoryLabel.Name = "directoryLabel";
-			// 
-			// fileLabel
-			// 
-			this.fileLabel.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.fileLabel, "fileLabel");
-			this.fileLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
-			this.fileLabel.Name = "fileLabel";
-			// 
-			// sizeLabel
-			// 
-			this.sizeLabel.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.sizeLabel, "sizeLabel");
-			this.sizeLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
-			this.sizeLabel.Name = "sizeLabel";
-			// 
-			// zoomLabel
-			// 
-			this.zoomLabel.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.zoomLabel, "zoomLabel");
-			this.zoomLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
-			this.zoomLabel.Name = "zoomLabel";
-			// 
-			// hasChangesLabel
-			// 
-			this.hasChangesLabel.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.hasChangesLabel, "hasChangesLabel");
-			this.hasChangesLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
-			this.hasChangesLabel.Name = "hasChangesLabel";
-			// 
-			// dateCreatedLabel
-			// 
-			this.dateCreatedLabel.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.dateCreatedLabel, "dateCreatedLabel");
-			this.dateCreatedLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
-			this.dateCreatedLabel.Name = "dateCreatedLabel";
-			// 
-			// dateModifiedLabel
-			// 
-			this.dateModifiedLabel.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.dateModifiedLabel, "dateModifiedLabel");
-			this.dateModifiedLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
-			this.dateModifiedLabel.Name = "dateModifiedLabel";
-			// 
-			// printDialog1
-			// 
-			this.printDialog1.Document = this.printDocument1;
-			this.printDialog1.UseEXDialog = true;
-			// 
-			// printDocument1
-			// 
-			this.printDocument1.DocumentName = "";
-			this.printDocument1.OriginAtMargins = true;
-			this.printDocument1.PrintPage += new System.Drawing.Printing.PrintPageEventHandler(this.printDocument1_PrintPage);
-			// 
-			// colorDialog1
-			// 
-			this.colorDialog1.Color = System.Drawing.Color.Blue;
-			// 
-			// toolStrip1
-			// 
-			this.toolStrip1.AlternativeAppearance = true;
-			resources.ApplyResources(this.toolStrip1, "toolStrip1");
-			this.toolStrip1.BackColor = System.Drawing.Color.White;
-			this.toolStrip1.CanOverflow = false;
-			this.toolStrip1.DarkMode = false;
-			this.toolStrip1.DragForm = true;
-			this.toolStrip1.ForeColor = System.Drawing.Color.Black;
-			this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-			this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.statusStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.ShowItemToolTips = true;
+            this.statusStrip1.VisibleChanged += new System.EventHandler(this.statusStrip1_VisibleChanged);
+            // 
+            // printDialog1
+            // 
+            this.printDialog1.Document = this.printDocument1;
+            this.printDialog1.UseEXDialog = true;
+            // 
+            // printDocument1
+            // 
+            this.printDocument1.DocumentName = "";
+            this.printDocument1.OriginAtMargins = true;
+            this.printDocument1.PrintPage += new System.Drawing.Printing.PrintPageEventHandler(this.printDocument1_PrintPage);
+            // 
+            // colorDialog1
+            // 
+            this.colorDialog1.Color = System.Drawing.Color.Blue;
+            // 
+            // toolStrip1
+            // 
+            this.toolStrip1.AlternativeAppearance = true;
+            resources.ApplyResources(this.toolStrip1, "toolStrip1");
+            this.toolStrip1.BackColor = System.Drawing.Color.White;
+            this.toolStrip1.CanOverflow = false;
+            this.toolStrip1.DarkMode = false;
+            this.toolStrip1.DragForm = true;
+            this.toolStrip1.ForeColor = System.Drawing.Color.Black;
+            this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.openButton,
+            this.openFolderButton,
             this.saveAsButton,
             this.externalBtn,
             this.toolStripSeparator4,
@@ -260,182 +214,315 @@
             this.qlibToolsep1,
             this.moreButton,
             this.framelessCloseBtn});
-			this.toolStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
-			this.toolStrip1.Name = "toolStrip1";
-			this.toolStrip1.VisibleChanged += new System.EventHandler(this.toolStrip1_VisibleChanged);
-			// 
-			// openButton
-			// 
-			resources.ApplyResources(this.openButton, "openButton");
-			this.openButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.openButton.Image = global::quick_picture_viewer.Properties.Resources.black_open;
-			this.openButton.Margin = new System.Windows.Forms.Padding(0);
-			this.openButton.Name = "openButton";
-			this.openButton.Click += new System.EventHandler(this.openButton_Click_1);
-			// 
-			// saveAsButton
-			// 
-			resources.ApplyResources(this.saveAsButton, "saveAsButton");
-			this.saveAsButton.BackColor = System.Drawing.Color.Transparent;
-			this.saveAsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.saveAsButton.Image = global::quick_picture_viewer.Properties.Resources.black_saveas;
-			this.saveAsButton.Margin = new System.Windows.Forms.Padding(0);
-			this.saveAsButton.Name = "saveAsButton";
-			this.saveAsButton.Click += new System.EventHandler(this.saveAsButton_Click);
-			// 
-			// externalBtn
-			// 
-			resources.ApplyResources(this.externalBtn, "externalBtn");
-			this.externalBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.externalBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+            this.toolStrip1.Name = "toolStrip1";
+            this.toolStrip1.VisibleChanged += new System.EventHandler(this.toolStrip1_VisibleChanged);
+            // 
+            // toolStripSeparator4
+            // 
+            resources.ApplyResources(this.toolStripSeparator4, "toolStripSeparator4");
+            this.toolStripSeparator4.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator4.DarkMode = false;
+            this.toolStripSeparator4.InsideMenu = false;
+            this.toolStripSeparator4.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.toolStripSeparator4.Name = "toolStripSeparator4";
+            // 
+            // toolStripSeparator1
+            // 
+            resources.ApplyResources(this.toolStripSeparator1, "toolStripSeparator1");
+            this.toolStripSeparator1.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator1.DarkMode = false;
+            this.toolStripSeparator1.InsideMenu = false;
+            this.toolStripSeparator1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            // 
+            // zoomTextBox
+            // 
+            this.zoomTextBox.BackColor = System.Drawing.Color.White;
+            this.zoomTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            resources.ApplyResources(this.zoomTextBox, "zoomTextBox");
+            this.zoomTextBox.Margin = new System.Windows.Forms.Padding(7, -1, 7, -1);
+            this.zoomTextBox.Name = "zoomTextBox";
+            this.zoomTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.zoomTextBox_KeyPress);
+            this.zoomTextBox.MouseEnter += new System.EventHandler(this.zoomTextBox_MouseEnter);
+            this.zoomTextBox.MouseLeave += new System.EventHandler(this.zoomTextBox_MouseLeave);
+            this.zoomTextBox.TextChanged += new System.EventHandler(this.zoomComboBox_TextChanged);
+            // 
+            // toolStripSeparator2
+            // 
+            resources.ApplyResources(this.toolStripSeparator2, "toolStripSeparator2");
+            this.toolStripSeparator2.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator2.DarkMode = false;
+            this.toolStripSeparator2.InsideMenu = false;
+            this.toolStripSeparator2.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            // 
+            // toolStripSeparator3
+            // 
+            resources.ApplyResources(this.toolStripSeparator3, "toolStripSeparator3");
+            this.toolStripSeparator3.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator3.DarkMode = false;
+            this.toolStripSeparator3.InsideMenu = false;
+            this.toolStripSeparator3.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            // 
+            // toolStripSeparator5
+            // 
+            resources.ApplyResources(this.toolStripSeparator5, "toolStripSeparator5");
+            this.toolStripSeparator5.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator5.DarkMode = false;
+            this.toolStripSeparator5.InsideMenu = false;
+            this.toolStripSeparator5.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            // 
+            // qlibToolsep1
+            // 
+            resources.ApplyResources(this.qlibToolsep1, "qlibToolsep1");
+            this.qlibToolsep1.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.qlibToolsep1.DarkMode = false;
+            this.qlibToolsep1.InsideMenu = false;
+            this.qlibToolsep1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.qlibToolsep1.Name = "qlibToolsep1";
+            // 
+            // rmbMenu
+            // 
+            resources.ApplyResources(this.rmbMenu, "rmbMenu");
+            this.rmbMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.showMenuItem});
+            this.rmbMenu.Name = "rmbMenu";
+            // 
+            // picturePanel
+            // 
+            resources.ApplyResources(this.picturePanel, "picturePanel");
+            this.picturePanel.BackColor = System.Drawing.Color.Transparent;
+            this.picturePanel.ContextMenuStrip = this.rmbMenu;
+            this.picturePanel.Controls.Add(this.suggestionIcon);
+            this.picturePanel.Controls.Add(this.suggestionLabel);
+            this.picturePanel.Controls.Add(this.pleaseOpenLabel);
+            this.picturePanel.Controls.Add(this.pictureBox);
+            this.picturePanel.Name = "picturePanel";
+            this.picturePanel.DoubleClick += new System.EventHandler(this.picturePanel_DoubleClick);
+            this.picturePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseDown);
+            this.picturePanel.MouseEnter += new System.EventHandler(this.picturePanel_MouseEnter);
+            this.picturePanel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseMove);
+            this.picturePanel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseUp);
+            // 
+            // suggestionLabel
+            // 
+            resources.ApplyResources(this.suggestionLabel, "suggestionLabel");
+            this.suggestionLabel.BackColor = System.Drawing.Color.Black;
+            this.suggestionLabel.ForeColor = System.Drawing.Color.White;
+            this.suggestionLabel.Name = "suggestionLabel";
+            // 
+            // pleaseOpenLabel
+            // 
+            resources.ApplyResources(this.pleaseOpenLabel, "pleaseOpenLabel");
+            this.pleaseOpenLabel.Name = "pleaseOpenLabel";
+            this.pleaseOpenLabel.DoubleClick += new System.EventHandler(this.picturePanel_DoubleClick);
+            // 
+            // typeOpsButton
+            // 
+            resources.ApplyResources(this.typeOpsButton, "typeOpsButton");
+            this.typeOpsButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.typeOpsButton.FlatAppearance.BorderSize = 0;
+            this.typeOpsButton.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.typeOpsButton.Name = "typeOpsButton";
+            this.typeOpsButton.TabStop = false;
+            this.typeOpsButton.UseVisualStyleBackColor = false;
+            this.typeOpsButton.VisibleChanged += new System.EventHandler(this.typeOpsButton_VisibleChanged);
+            this.typeOpsButton.Click += new System.EventHandler(this.typeOpsButton_Click);
+            // 
+            // directoryLabel
+            // 
+            this.directoryLabel.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.directoryLabel, "directoryLabel");
+            this.directoryLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
+            this.directoryLabel.Name = "directoryLabel";
+            // 
+            // fileLabel
+            // 
+            this.fileLabel.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.fileLabel, "fileLabel");
+            this.fileLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
+            this.fileLabel.Name = "fileLabel";
+            // 
+            // sizeLabel
+            // 
+            this.sizeLabel.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.sizeLabel, "sizeLabel");
+            this.sizeLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
+            this.sizeLabel.Name = "sizeLabel";
+            // 
+            // zoomLabel
+            // 
+            this.zoomLabel.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.zoomLabel, "zoomLabel");
+            this.zoomLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
+            this.zoomLabel.Name = "zoomLabel";
+            // 
+            // hasChangesLabel
+            // 
+            this.hasChangesLabel.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.hasChangesLabel, "hasChangesLabel");
+            this.hasChangesLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
+            this.hasChangesLabel.Name = "hasChangesLabel";
+            // 
+            // dateCreatedLabel
+            // 
+            this.dateCreatedLabel.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.dateCreatedLabel, "dateCreatedLabel");
+            this.dateCreatedLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
+            this.dateCreatedLabel.Name = "dateCreatedLabel";
+            // 
+            // dateModifiedLabel
+            // 
+            this.dateModifiedLabel.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.dateModifiedLabel, "dateModifiedLabel");
+            this.dateModifiedLabel.Margin = new System.Windows.Forms.Padding(6, 6, 0, 6);
+            this.dateModifiedLabel.Name = "dateModifiedLabel";
+            // 
+            // openButton
+            // 
+            resources.ApplyResources(this.openButton, "openButton");
+            this.openButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.openButton.Image = global::quick_picture_viewer.Properties.Resources.black_open;
+            this.openButton.Margin = new System.Windows.Forms.Padding(0);
+            this.openButton.Name = "openButton";
+            this.openButton.Click += new System.EventHandler(this.openButton_Click_1);
+            // 
+            // openFolderButton
+            // 
+            resources.ApplyResources(this.openFolderButton, "openFolderButton");
+            this.openFolderButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.openFolderButton.Image = global::quick_picture_viewer.Properties.Resources.black_picfolder;
+            this.openFolderButton.Margin = new System.Windows.Forms.Padding(0);
+            this.openFolderButton.Name = "openFolderButton";
+            this.openFolderButton.Click += new System.EventHandler(this.openFolderButton_Click);
+            // 
+            // saveAsButton
+            // 
+            resources.ApplyResources(this.saveAsButton, "saveAsButton");
+            this.saveAsButton.BackColor = System.Drawing.Color.Transparent;
+            this.saveAsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.saveAsButton.Image = global::quick_picture_viewer.Properties.Resources.black_saveas;
+            this.saveAsButton.Margin = new System.Windows.Forms.Padding(0);
+            this.saveAsButton.Name = "saveAsButton";
+            this.saveAsButton.Click += new System.EventHandler(this.saveAsButton_Click);
+            // 
+            // externalBtn
+            // 
+            resources.ApplyResources(this.externalBtn, "externalBtn");
+            this.externalBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.externalBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.externalRunBtn,
             this.externalFavoriteBtn,
             this.externalChooseBtn});
-			this.externalBtn.Margin = new System.Windows.Forms.Padding(0);
-			this.externalBtn.Name = "externalBtn";
-			this.externalBtn.DropDownOpened += new System.EventHandler(this.externalBtn_DropDownOpened);
-			// 
-			// externalRunBtn
-			// 
-			this.externalRunBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.externalRunBtn, "externalRunBtn");
-			this.externalRunBtn.ForeColor = System.Drawing.Color.Black;
-			this.externalRunBtn.Name = "externalRunBtn";
-			this.externalRunBtn.Click += new System.EventHandler(this.externalRunBtn_Click);
-			// 
-			// externalFavoriteBtn
-			// 
-			this.externalFavoriteBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.externalFavoriteBtn, "externalFavoriteBtn");
-			this.externalFavoriteBtn.ForeColor = System.Drawing.Color.Black;
-			this.externalFavoriteBtn.Image = global::quick_picture_viewer.Properties.Resources.black_paint;
-			this.externalFavoriteBtn.Name = "externalFavoriteBtn";
-			this.externalFavoriteBtn.Click += new System.EventHandler(this.externalFavoriteBtn_Click);
-			// 
-			// externalChooseBtn
-			// 
-			this.externalChooseBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.externalChooseBtn, "externalChooseBtn");
-			this.externalChooseBtn.ForeColor = System.Drawing.Color.Black;
-			this.externalChooseBtn.Name = "externalChooseBtn";
-			this.externalChooseBtn.Click += new System.EventHandler(this.externalButton_Click);
-			// 
-			// toolStripSeparator4
-			// 
-			resources.ApplyResources(this.toolStripSeparator4, "toolStripSeparator4");
-			this.toolStripSeparator4.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator4.DarkMode = false;
-			this.toolStripSeparator4.InsideMenu = false;
-			this.toolStripSeparator4.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			// 
-			// infoButton
-			// 
-			resources.ApplyResources(this.infoButton, "infoButton");
-			this.infoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.infoButton.Margin = new System.Windows.Forms.Padding(0);
-			this.infoButton.Name = "infoButton";
-			this.infoButton.Click += new System.EventHandler(this.infoButton_Click);
-			// 
-			// prevButton
-			// 
-			resources.ApplyResources(this.prevButton, "prevButton");
-			this.prevButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.prevButton.Margin = new System.Windows.Forms.Padding(0);
-			this.prevButton.Name = "prevButton";
-			this.prevButton.Click += new System.EventHandler(this.prevButton_Click);
-			// 
-			// slideshowButton
-			// 
-			resources.ApplyResources(this.slideshowButton, "slideshowButton");
-			this.slideshowButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.slideshowButton.Margin = new System.Windows.Forms.Padding(0);
-			this.slideshowButton.Name = "slideshowButton";
-			this.slideshowButton.Click += new System.EventHandler(this.slideshowButton_Click);
-			// 
-			// nextButton
-			// 
-			resources.ApplyResources(this.nextButton, "nextButton");
-			this.nextButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.nextButton.Margin = new System.Windows.Forms.Padding(0);
-			this.nextButton.Name = "nextButton";
-			this.nextButton.Click += new System.EventHandler(this.nextButton_Click);
-			// 
-			// showFileButton
-			// 
-			resources.ApplyResources(this.showFileButton, "showFileButton");
-			this.showFileButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.showFileButton.Margin = new System.Windows.Forms.Padding(0);
-			this.showFileButton.Name = "showFileButton";
-			this.showFileButton.Click += new System.EventHandler(this.showFileButton_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			resources.ApplyResources(this.toolStripSeparator1, "toolStripSeparator1");
-			this.toolStripSeparator1.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator1.DarkMode = false;
-			this.toolStripSeparator1.InsideMenu = false;
-			this.toolStripSeparator1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			// 
-			// autoZoomButton
-			// 
-			resources.ApplyResources(this.autoZoomButton, "autoZoomButton");
-			this.autoZoomButton.Checked = true;
-			this.autoZoomButton.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.autoZoomButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.autoZoomButton.Margin = new System.Windows.Forms.Padding(0);
-			this.autoZoomButton.Name = "autoZoomButton";
-			this.autoZoomButton.Click += new System.EventHandler(this.autoZoomButton_Click);
-			// 
-			// zoomOutButton
-			// 
-			resources.ApplyResources(this.zoomOutButton, "zoomOutButton");
-			this.zoomOutButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.zoomOutButton.Margin = new System.Windows.Forms.Padding(0);
-			this.zoomOutButton.Name = "zoomOutButton";
-			this.zoomOutButton.Click += new System.EventHandler(this.zoomOutButton_Click);
-			this.zoomOutButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.zoomOutButton_MouseDown);
-			this.zoomOutButton.MouseLeave += new System.EventHandler(this.zoomOutButton_MouseLeave);
-			this.zoomOutButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.zoomOutButton_MouseUp);
-			// 
-			// zoomTextBox
-			// 
-			this.zoomTextBox.BackColor = System.Drawing.Color.White;
-			this.zoomTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			resources.ApplyResources(this.zoomTextBox, "zoomTextBox");
-			this.zoomTextBox.Margin = new System.Windows.Forms.Padding(7, -1, 7, -1);
-			this.zoomTextBox.Name = "zoomTextBox";
-			this.zoomTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.zoomTextBox_KeyPress);
-			this.zoomTextBox.MouseEnter += new System.EventHandler(this.zoomTextBox_MouseEnter);
-			this.zoomTextBox.MouseLeave += new System.EventHandler(this.zoomTextBox_MouseLeave);
-			this.zoomTextBox.TextChanged += new System.EventHandler(this.zoomComboBox_TextChanged);
-			// 
-			// zoomInButton
-			// 
-			resources.ApplyResources(this.zoomInButton, "zoomInButton");
-			this.zoomInButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.zoomInButton.Margin = new System.Windows.Forms.Padding(0);
-			this.zoomInButton.Name = "zoomInButton";
-			this.zoomInButton.Click += new System.EventHandler(this.zoomInButton_Click);
-			this.zoomInButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.zoomInButton_MouseDown);
-			this.zoomInButton.MouseLeave += new System.EventHandler(this.zoomInButton_MouseLeave);
-			this.zoomInButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.zoomInButton_MouseUp);
-			// 
-			// toolStripSeparator2
-			// 
-			resources.ApplyResources(this.toolStripSeparator2, "toolStripSeparator2");
-			this.toolStripSeparator2.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator2.DarkMode = false;
-			this.toolStripSeparator2.InsideMenu = false;
-			this.toolStripSeparator2.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			// 
-			// editButton
-			// 
-			resources.ApplyResources(this.editButton, "editButton");
-			this.editButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.editButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.externalBtn.Margin = new System.Windows.Forms.Padding(0);
+            this.externalBtn.Name = "externalBtn";
+            this.externalBtn.DropDownOpened += new System.EventHandler(this.externalBtn_DropDownOpened);
+            // 
+            // externalRunBtn
+            // 
+            this.externalRunBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.externalRunBtn, "externalRunBtn");
+            this.externalRunBtn.ForeColor = System.Drawing.Color.Black;
+            this.externalRunBtn.Name = "externalRunBtn";
+            this.externalRunBtn.Click += new System.EventHandler(this.externalRunBtn_Click);
+            // 
+            // externalFavoriteBtn
+            // 
+            this.externalFavoriteBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.externalFavoriteBtn, "externalFavoriteBtn");
+            this.externalFavoriteBtn.ForeColor = System.Drawing.Color.Black;
+            this.externalFavoriteBtn.Image = global::quick_picture_viewer.Properties.Resources.black_paint;
+            this.externalFavoriteBtn.Name = "externalFavoriteBtn";
+            this.externalFavoriteBtn.Click += new System.EventHandler(this.externalFavoriteBtn_Click);
+            // 
+            // externalChooseBtn
+            // 
+            this.externalChooseBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.externalChooseBtn, "externalChooseBtn");
+            this.externalChooseBtn.ForeColor = System.Drawing.Color.Black;
+            this.externalChooseBtn.Name = "externalChooseBtn";
+            this.externalChooseBtn.Click += new System.EventHandler(this.externalButton_Click);
+            // 
+            // infoButton
+            // 
+            resources.ApplyResources(this.infoButton, "infoButton");
+            this.infoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.infoButton.Margin = new System.Windows.Forms.Padding(0);
+            this.infoButton.Name = "infoButton";
+            this.infoButton.Click += new System.EventHandler(this.infoButton_Click);
+            // 
+            // prevButton
+            // 
+            resources.ApplyResources(this.prevButton, "prevButton");
+            this.prevButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.prevButton.Margin = new System.Windows.Forms.Padding(0);
+            this.prevButton.Name = "prevButton";
+            this.prevButton.Click += new System.EventHandler(this.prevButton_Click);
+            // 
+            // slideshowButton
+            // 
+            resources.ApplyResources(this.slideshowButton, "slideshowButton");
+            this.slideshowButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.slideshowButton.Margin = new System.Windows.Forms.Padding(0);
+            this.slideshowButton.Name = "slideshowButton";
+            this.slideshowButton.Click += new System.EventHandler(this.slideshowButton_Click);
+            // 
+            // nextButton
+            // 
+            resources.ApplyResources(this.nextButton, "nextButton");
+            this.nextButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.nextButton.Margin = new System.Windows.Forms.Padding(0);
+            this.nextButton.Name = "nextButton";
+            this.nextButton.Click += new System.EventHandler(this.nextButton_Click);
+            // 
+            // showFileButton
+            // 
+            resources.ApplyResources(this.showFileButton, "showFileButton");
+            this.showFileButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.showFileButton.Margin = new System.Windows.Forms.Padding(0);
+            this.showFileButton.Name = "showFileButton";
+            this.showFileButton.Click += new System.EventHandler(this.showFileButton_Click);
+            // 
+            // autoZoomButton
+            // 
+            resources.ApplyResources(this.autoZoomButton, "autoZoomButton");
+            this.autoZoomButton.Checked = true;
+            this.autoZoomButton.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoZoomButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.autoZoomButton.Margin = new System.Windows.Forms.Padding(0);
+            this.autoZoomButton.Name = "autoZoomButton";
+            this.autoZoomButton.Click += new System.EventHandler(this.autoZoomButton_Click);
+            // 
+            // zoomOutButton
+            // 
+            resources.ApplyResources(this.zoomOutButton, "zoomOutButton");
+            this.zoomOutButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.zoomOutButton.Margin = new System.Windows.Forms.Padding(0);
+            this.zoomOutButton.Name = "zoomOutButton";
+            this.zoomOutButton.Click += new System.EventHandler(this.zoomOutButton_Click);
+            this.zoomOutButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.zoomOutButton_MouseDown);
+            this.zoomOutButton.MouseLeave += new System.EventHandler(this.zoomOutButton_MouseLeave);
+            this.zoomOutButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.zoomOutButton_MouseUp);
+            // 
+            // zoomInButton
+            // 
+            resources.ApplyResources(this.zoomInButton, "zoomInButton");
+            this.zoomInButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.zoomInButton.Margin = new System.Windows.Forms.Padding(0);
+            this.zoomInButton.Name = "zoomInButton";
+            this.zoomInButton.Click += new System.EventHandler(this.zoomInButton_Click);
+            this.zoomInButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.zoomInButton_MouseDown);
+            this.zoomInButton.MouseLeave += new System.EventHandler(this.zoomInButton_MouseLeave);
+            this.zoomInButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.zoomInButton_MouseUp);
+            // 
+            // editButton
+            // 
+            resources.ApplyResources(this.editButton, "editButton");
+            this.editButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.editButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.flipHorizontalButton,
             this.flipVerticalButton,
             this.toolStripSeparator7,
@@ -443,197 +530,170 @@
             this.rotateLeftButton,
             this.rotate180Button,
             this.customAngleBtn});
-			this.editButton.Margin = new System.Windows.Forms.Padding(0);
-			this.editButton.Name = "editButton";
-			// 
-			// flipHorizontalButton
-			// 
-			this.flipHorizontalButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.flipHorizontalButton, "flipHorizontalButton");
-			this.flipHorizontalButton.ForeColor = System.Drawing.Color.Black;
-			this.flipHorizontalButton.Name = "flipHorizontalButton";
-			this.flipHorizontalButton.Click += new System.EventHandler(this.flipHorizontalButton_Click);
-			// 
-			// flipVerticalButton
-			// 
-			this.flipVerticalButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.flipVerticalButton, "flipVerticalButton");
-			this.flipVerticalButton.ForeColor = System.Drawing.Color.Black;
-			this.flipVerticalButton.Name = "flipVerticalButton";
-			this.flipVerticalButton.Click += new System.EventHandler(this.flipVerticalButton_Click);
-			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator7.DarkMode = false;
-			this.toolStripSeparator7.InsideMenu = true;
-			this.toolStripSeparator7.Margin = new System.Windows.Forms.Padding(4);
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			resources.ApplyResources(this.toolStripSeparator7, "toolStripSeparator7");
-			// 
-			// rotateRightButton
-			// 
-			this.rotateRightButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.rotateRightButton, "rotateRightButton");
-			this.rotateRightButton.ForeColor = System.Drawing.Color.Black;
-			this.rotateRightButton.Name = "rotateRightButton";
-			this.rotateRightButton.Click += new System.EventHandler(this.rotateRightButton_Click);
-			// 
-			// rotateLeftButton
-			// 
-			this.rotateLeftButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.rotateLeftButton, "rotateLeftButton");
-			this.rotateLeftButton.ForeColor = System.Drawing.Color.Black;
-			this.rotateLeftButton.Name = "rotateLeftButton";
-			this.rotateLeftButton.Click += new System.EventHandler(this.rotateLeftButton_Click);
-			// 
-			// rotate180Button
-			// 
-			this.rotate180Button.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.rotate180Button, "rotate180Button");
-			this.rotate180Button.ForeColor = System.Drawing.Color.Black;
-			this.rotate180Button.Name = "rotate180Button";
-			this.rotate180Button.Click += new System.EventHandler(this.rotate180Button_Click);
-			// 
-			// customAngleBtn
-			// 
-			this.customAngleBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.customAngleBtn, "customAngleBtn");
-			this.customAngleBtn.ForeColor = System.Drawing.Color.Black;
-			this.customAngleBtn.Image = global::quick_picture_viewer.Properties.Resources.black_angle;
-			this.customAngleBtn.Name = "customAngleBtn";
-			// 
-			// copyButton
-			// 
-			resources.ApplyResources(this.copyButton, "copyButton");
-			this.copyButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.copyButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.editButton.Margin = new System.Windows.Forms.Padding(0);
+            this.editButton.Name = "editButton";
+            // 
+            // flipHorizontalButton
+            // 
+            this.flipHorizontalButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.flipHorizontalButton, "flipHorizontalButton");
+            this.flipHorizontalButton.ForeColor = System.Drawing.Color.Black;
+            this.flipHorizontalButton.Name = "flipHorizontalButton";
+            this.flipHorizontalButton.Click += new System.EventHandler(this.flipHorizontalButton_Click);
+            // 
+            // flipVerticalButton
+            // 
+            this.flipVerticalButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.flipVerticalButton, "flipVerticalButton");
+            this.flipVerticalButton.ForeColor = System.Drawing.Color.Black;
+            this.flipVerticalButton.Name = "flipVerticalButton";
+            this.flipVerticalButton.Click += new System.EventHandler(this.flipVerticalButton_Click);
+            // 
+            // toolStripSeparator7
+            // 
+            this.toolStripSeparator7.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator7.DarkMode = false;
+            this.toolStripSeparator7.InsideMenu = true;
+            this.toolStripSeparator7.Margin = new System.Windows.Forms.Padding(4);
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            resources.ApplyResources(this.toolStripSeparator7, "toolStripSeparator7");
+            // 
+            // rotateRightButton
+            // 
+            this.rotateRightButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.rotateRightButton, "rotateRightButton");
+            this.rotateRightButton.ForeColor = System.Drawing.Color.Black;
+            this.rotateRightButton.Name = "rotateRightButton";
+            this.rotateRightButton.Click += new System.EventHandler(this.rotateRightButton_Click);
+            // 
+            // rotateLeftButton
+            // 
+            this.rotateLeftButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.rotateLeftButton, "rotateLeftButton");
+            this.rotateLeftButton.ForeColor = System.Drawing.Color.Black;
+            this.rotateLeftButton.Name = "rotateLeftButton";
+            this.rotateLeftButton.Click += new System.EventHandler(this.rotateLeftButton_Click);
+            // 
+            // rotate180Button
+            // 
+            this.rotate180Button.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.rotate180Button, "rotate180Button");
+            this.rotate180Button.ForeColor = System.Drawing.Color.Black;
+            this.rotate180Button.Name = "rotate180Button";
+            this.rotate180Button.Click += new System.EventHandler(this.rotate180Button_Click);
+            // 
+            // customAngleBtn
+            // 
+            this.customAngleBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.customAngleBtn, "customAngleBtn");
+            this.customAngleBtn.ForeColor = System.Drawing.Color.Black;
+            this.customAngleBtn.Image = global::quick_picture_viewer.Properties.Resources.black_angle;
+            this.customAngleBtn.Name = "customAngleBtn";
+            // 
+            // copyButton
+            // 
+            resources.ApplyResources(this.copyButton, "copyButton");
+            this.copyButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.copyButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyImageButton,
             this.copyFileBtn});
-			this.copyButton.Margin = new System.Windows.Forms.Padding(0);
-			this.copyButton.Name = "copyButton";
-			// 
-			// copyImageButton
-			// 
-			this.copyImageButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.copyImageButton, "copyImageButton");
-			this.copyImageButton.ForeColor = System.Drawing.Color.Black;
-			this.copyImageButton.Name = "copyImageButton";
-			this.copyImageButton.Click += new System.EventHandler(this.copyButton_Click);
-			// 
-			// copyFileBtn
-			// 
-			this.copyFileBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.copyFileBtn, "copyFileBtn");
-			this.copyFileBtn.ForeColor = System.Drawing.Color.Black;
-			this.copyFileBtn.Name = "copyFileBtn";
-			this.copyFileBtn.Click += new System.EventHandler(this.copyFileBtn_Click);
-			// 
-			// pasteButton
-			// 
-			resources.ApplyResources(this.pasteButton, "pasteButton");
-			this.pasteButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.pasteButton.Margin = new System.Windows.Forms.Padding(0);
-			this.pasteButton.Name = "pasteButton";
-			this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
-			// 
-			// toolStripSeparator3
-			// 
-			resources.ApplyResources(this.toolStripSeparator3, "toolStripSeparator3");
-			this.toolStripSeparator3.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator3.DarkMode = false;
-			this.toolStripSeparator3.InsideMenu = false;
-			this.toolStripSeparator3.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			// 
-			// checkboardButton
-			// 
-			resources.ApplyResources(this.checkboardButton, "checkboardButton");
-			this.checkboardButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.checkboardButton.Image = global::quick_picture_viewer.Properties.Resources.black_grid;
-			this.checkboardButton.Margin = new System.Windows.Forms.Padding(0);
-			this.checkboardButton.Name = "checkboardButton";
-			this.checkboardButton.Click += new System.EventHandler(this.checkboardButton_Click);
-			// 
-			// fullscreenBtn
-			// 
-			resources.ApplyResources(this.fullscreenBtn, "fullscreenBtn");
-			this.fullscreenBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.fullscreenBtn.Margin = new System.Windows.Forms.Padding(0);
-			this.fullscreenBtn.Name = "fullscreenBtn";
-			this.fullscreenBtn.Click += new System.EventHandler(this.fullscreenButton_Click);
-			// 
-			// miniViewButton
-			// 
-			resources.ApplyResources(this.miniViewButton, "miniViewButton");
-			this.miniViewButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.miniViewButton.Margin = new System.Windows.Forms.Padding(0);
-			this.miniViewButton.Name = "miniViewButton";
-			this.miniViewButton.Click += new System.EventHandler(this.miniViewButton_Click);
-			// 
-			// toolStripSeparator5
-			// 
-			resources.ApplyResources(this.toolStripSeparator5, "toolStripSeparator5");
-			this.toolStripSeparator5.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator5.DarkMode = false;
-			this.toolStripSeparator5.InsideMenu = false;
-			this.toolStripSeparator5.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			// 
-			// effectsBtn
-			// 
-			resources.ApplyResources(this.effectsBtn, "effectsBtn");
-			this.effectsBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.effectsBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copyButton.Margin = new System.Windows.Forms.Padding(0);
+            this.copyButton.Name = "copyButton";
+            // 
+            // copyImageButton
+            // 
+            this.copyImageButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.copyImageButton, "copyImageButton");
+            this.copyImageButton.ForeColor = System.Drawing.Color.Black;
+            this.copyImageButton.Name = "copyImageButton";
+            this.copyImageButton.Click += new System.EventHandler(this.copyButton_Click);
+            // 
+            // copyFileBtn
+            // 
+            this.copyFileBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.copyFileBtn, "copyFileBtn");
+            this.copyFileBtn.ForeColor = System.Drawing.Color.Black;
+            this.copyFileBtn.Name = "copyFileBtn";
+            this.copyFileBtn.Click += new System.EventHandler(this.copyFileBtn_Click);
+            // 
+            // pasteButton
+            // 
+            resources.ApplyResources(this.pasteButton, "pasteButton");
+            this.pasteButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.pasteButton.Margin = new System.Windows.Forms.Padding(0);
+            this.pasteButton.Name = "pasteButton";
+            this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+            // 
+            // checkboardButton
+            // 
+            resources.ApplyResources(this.checkboardButton, "checkboardButton");
+            this.checkboardButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.checkboardButton.Image = global::quick_picture_viewer.Properties.Resources.black_grid;
+            this.checkboardButton.Margin = new System.Windows.Forms.Padding(0);
+            this.checkboardButton.Name = "checkboardButton";
+            this.checkboardButton.Click += new System.EventHandler(this.checkboardButton_Click);
+            // 
+            // fullscreenBtn
+            // 
+            resources.ApplyResources(this.fullscreenBtn, "fullscreenBtn");
+            this.fullscreenBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.fullscreenBtn.Margin = new System.Windows.Forms.Padding(0);
+            this.fullscreenBtn.Name = "fullscreenBtn";
+            this.fullscreenBtn.Click += new System.EventHandler(this.fullscreenButton_Click);
+            // 
+            // miniViewButton
+            // 
+            resources.ApplyResources(this.miniViewButton, "miniViewButton");
+            this.miniViewButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.miniViewButton.Margin = new System.Windows.Forms.Padding(0);
+            this.miniViewButton.Name = "miniViewButton";
+            this.miniViewButton.Click += new System.EventHandler(this.miniViewButton_Click);
+            // 
+            // effectsBtn
+            // 
+            resources.ApplyResources(this.effectsBtn, "effectsBtn");
+            this.effectsBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.effectsBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.pluginManBtn});
-			this.effectsBtn.Image = global::quick_picture_viewer.Properties.Resources.black_effects;
-			this.effectsBtn.Margin = new System.Windows.Forms.Padding(0);
-			this.effectsBtn.Name = "effectsBtn";
-			this.effectsBtn.DropDownOpening += new System.EventHandler(this.effectsBtn_DropDownOpening);
-			// 
-			// pluginManBtn
-			// 
-			this.pluginManBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.pluginManBtn.ForeColor = System.Drawing.Color.Black;
-			this.pluginManBtn.Image = global::quick_picture_viewer.Properties.Resources.black_plugin;
-			this.pluginManBtn.Name = "pluginManBtn";
-			resources.ApplyResources(this.pluginManBtn, "pluginManBtn");
-			this.pluginManBtn.Click += new System.EventHandler(this.pluginManBtn_Click);
-			// 
-			// toolsBtn
-			// 
-			resources.ApplyResources(this.toolsBtn, "toolsBtn");
-			this.toolsBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolsBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.effectsBtn.Image = global::quick_picture_viewer.Properties.Resources.black_effects;
+            this.effectsBtn.Margin = new System.Windows.Forms.Padding(0);
+            this.effectsBtn.Name = "effectsBtn";
+            this.effectsBtn.DropDownOpening += new System.EventHandler(this.effectsBtn_DropDownOpening);
+            // 
+            // pluginManBtn
+            // 
+            this.pluginManBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.pluginManBtn.ForeColor = System.Drawing.Color.Black;
+            this.pluginManBtn.Image = global::quick_picture_viewer.Properties.Resources.black_plugin;
+            this.pluginManBtn.Name = "pluginManBtn";
+            resources.ApplyResources(this.pluginManBtn, "pluginManBtn");
+            this.pluginManBtn.Click += new System.EventHandler(this.pluginManBtn_Click);
+            // 
+            // toolsBtn
+            // 
+            resources.ApplyResources(this.toolsBtn, "toolsBtn");
+            this.toolsBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolsBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.pluginManBtn2});
-			this.toolsBtn.Image = global::quick_picture_viewer.Properties.Resources.black_tools;
-			this.toolsBtn.Margin = new System.Windows.Forms.Padding(0);
-			this.toolsBtn.Name = "toolsBtn";
-			this.toolsBtn.DropDownOpening += new System.EventHandler(this.effectsBtn_DropDownOpening);
-			// 
-			// pluginManBtn2
-			// 
-			this.pluginManBtn2.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.pluginManBtn2.ForeColor = System.Drawing.Color.Black;
-			this.pluginManBtn2.Image = global::quick_picture_viewer.Properties.Resources.black_plugin;
-			this.pluginManBtn2.Name = "pluginManBtn2";
-			resources.ApplyResources(this.pluginManBtn2, "pluginManBtn2");
-			this.pluginManBtn2.Click += new System.EventHandler(this.pluginManBtn_Click);
-			// 
-			// qlibToolsep1
-			// 
-			resources.ApplyResources(this.qlibToolsep1, "qlibToolsep1");
-			this.qlibToolsep1.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.qlibToolsep1.DarkMode = false;
-			this.qlibToolsep1.InsideMenu = false;
-			this.qlibToolsep1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
-			this.qlibToolsep1.Name = "qlibToolsep1";
-			// 
-			// moreButton
-			// 
-			resources.ApplyResources(this.moreButton, "moreButton");
-			this.moreButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.moreButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolsBtn.Image = global::quick_picture_viewer.Properties.Resources.black_tools;
+            this.toolsBtn.Margin = new System.Windows.Forms.Padding(0);
+            this.toolsBtn.Name = "toolsBtn";
+            this.toolsBtn.DropDownOpening += new System.EventHandler(this.effectsBtn_DropDownOpening);
+            // 
+            // pluginManBtn2
+            // 
+            this.pluginManBtn2.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.pluginManBtn2.ForeColor = System.Drawing.Color.Black;
+            this.pluginManBtn2.Image = global::quick_picture_viewer.Properties.Resources.black_plugin;
+            this.pluginManBtn2.Name = "pluginManBtn2";
+            resources.ApplyResources(this.pluginManBtn2, "pluginManBtn2");
+            this.pluginManBtn2.Click += new System.EventHandler(this.pluginManBtn_Click);
+            // 
+            // moreButton
+            // 
+            resources.ApplyResources(this.moreButton, "moreButton");
+            this.moreButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.moreButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.reloadButton,
             this.deleteBtn,
             this.printButton,
@@ -648,295 +708,247 @@
             this.toolStripSeparator10,
             this.settingsButton,
             this.aboutBtn});
-			this.moreButton.Margin = new System.Windows.Forms.Padding(0);
-			this.moreButton.Name = "moreButton";
-			// 
-			// reloadButton
-			// 
-			this.reloadButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.reloadButton, "reloadButton");
-			this.reloadButton.ForeColor = System.Drawing.Color.Black;
-			this.reloadButton.Image = global::quick_picture_viewer.Properties.Resources.black_sync;
-			this.reloadButton.Name = "reloadButton";
-			this.reloadButton.Click += new System.EventHandler(this.reloadButton_Click);
-			// 
-			// deleteBtn
-			// 
-			this.deleteBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.deleteBtn, "deleteBtn");
-			this.deleteBtn.ForeColor = System.Drawing.Color.Black;
-			this.deleteBtn.Image = global::quick_picture_viewer.Properties.Resources.black_trash;
-			this.deleteBtn.Name = "deleteBtn";
-			this.deleteBtn.Click += new System.EventHandler(this.deleteButton_Click);
-			// 
-			// printButton
-			// 
-			this.printButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.printButton, "printButton");
-			this.printButton.ForeColor = System.Drawing.Color.Black;
-			this.printButton.Name = "printButton";
-			this.printButton.Click += new System.EventHandler(this.printButton_Click);
-			// 
-			// setAsDesktopButton
-			// 
-			this.setAsDesktopButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.setAsDesktopButton, "setAsDesktopButton");
-			this.setAsDesktopButton.ForeColor = System.Drawing.Color.Black;
-			this.setAsDesktopButton.Name = "setAsDesktopButton";
-			this.setAsDesktopButton.Click += new System.EventHandler(this.setAsDesktopButton_Click);
-			// 
-			// qlibMenuSeparator2
-			// 
-			this.qlibMenuSeparator2.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.qlibMenuSeparator2.DarkMode = false;
-			this.qlibMenuSeparator2.InsideMenu = true;
-			this.qlibMenuSeparator2.Margin = new System.Windows.Forms.Padding(4);
-			this.qlibMenuSeparator2.Name = "qlibMenuSeparator2";
-			resources.ApplyResources(this.qlibMenuSeparator2, "qlibMenuSeparator2");
-			// 
-			// actualSizeBtn
-			// 
-			this.actualSizeBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			resources.ApplyResources(this.actualSizeBtn, "actualSizeBtn");
-			this.actualSizeBtn.ForeColor = System.Drawing.Color.Black;
-			this.actualSizeBtn.Name = "actualSizeBtn";
-			this.actualSizeBtn.Click += new System.EventHandler(this.actualSizeBtn_Click);
-			// 
-			// toolStripSeparator9
-			// 
-			this.toolStripSeparator9.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator9.DarkMode = false;
-			this.toolStripSeparator9.InsideMenu = true;
-			this.toolStripSeparator9.Margin = new System.Windows.Forms.Padding(4);
-			this.toolStripSeparator9.Name = "toolStripSeparator9";
-			resources.ApplyResources(this.toolStripSeparator9, "toolStripSeparator9");
-			// 
-			// backColorBtn
-			// 
-			this.backColorBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.backColorBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.moreButton.Margin = new System.Windows.Forms.Padding(0);
+            this.moreButton.Name = "moreButton";
+            // 
+            // reloadButton
+            // 
+            this.reloadButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.reloadButton, "reloadButton");
+            this.reloadButton.ForeColor = System.Drawing.Color.Black;
+            this.reloadButton.Image = global::quick_picture_viewer.Properties.Resources.black_sync;
+            this.reloadButton.Name = "reloadButton";
+            this.reloadButton.Click += new System.EventHandler(this.reloadButton_Click);
+            // 
+            // deleteBtn
+            // 
+            this.deleteBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.deleteBtn, "deleteBtn");
+            this.deleteBtn.ForeColor = System.Drawing.Color.Black;
+            this.deleteBtn.Image = global::quick_picture_viewer.Properties.Resources.black_trash;
+            this.deleteBtn.Name = "deleteBtn";
+            this.deleteBtn.Click += new System.EventHandler(this.deleteButton_Click);
+            // 
+            // printButton
+            // 
+            this.printButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.printButton, "printButton");
+            this.printButton.ForeColor = System.Drawing.Color.Black;
+            this.printButton.Name = "printButton";
+            this.printButton.Click += new System.EventHandler(this.printButton_Click);
+            // 
+            // setAsDesktopButton
+            // 
+            this.setAsDesktopButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.setAsDesktopButton, "setAsDesktopButton");
+            this.setAsDesktopButton.ForeColor = System.Drawing.Color.Black;
+            this.setAsDesktopButton.Name = "setAsDesktopButton";
+            this.setAsDesktopButton.Click += new System.EventHandler(this.setAsDesktopButton_Click);
+            // 
+            // qlibMenuSeparator2
+            // 
+            this.qlibMenuSeparator2.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.qlibMenuSeparator2.DarkMode = false;
+            this.qlibMenuSeparator2.InsideMenu = true;
+            this.qlibMenuSeparator2.Margin = new System.Windows.Forms.Padding(4);
+            this.qlibMenuSeparator2.Name = "qlibMenuSeparator2";
+            resources.ApplyResources(this.qlibMenuSeparator2, "qlibMenuSeparator2");
+            // 
+            // actualSizeBtn
+            // 
+            this.actualSizeBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            resources.ApplyResources(this.actualSizeBtn, "actualSizeBtn");
+            this.actualSizeBtn.ForeColor = System.Drawing.Color.Black;
+            this.actualSizeBtn.Name = "actualSizeBtn";
+            this.actualSizeBtn.Click += new System.EventHandler(this.actualSizeBtn_Click);
+            // 
+            // toolStripSeparator9
+            // 
+            this.toolStripSeparator9.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator9.DarkMode = false;
+            this.toolStripSeparator9.InsideMenu = true;
+            this.toolStripSeparator9.Margin = new System.Windows.Forms.Padding(4);
+            this.toolStripSeparator9.Name = "toolStripSeparator9";
+            resources.ApplyResources(this.toolStripSeparator9, "toolStripSeparator9");
+            // 
+            // backColorBtn
+            // 
+            this.backColorBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.backColorBtn.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.backClearBtn,
             this.qlibMenuSeparator1,
             this.backCustomBtn});
-			this.backColorBtn.ForeColor = System.Drawing.Color.Black;
-			this.backColorBtn.Image = global::quick_picture_viewer.Properties.Resources.black_palette;
-			this.backColorBtn.Name = "backColorBtn";
-			resources.ApplyResources(this.backColorBtn, "backColorBtn");
-			// 
-			// backClearBtn
-			// 
-			this.backClearBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.backClearBtn.ForeColor = System.Drawing.Color.Black;
-			resources.ApplyResources(this.backClearBtn, "backClearBtn");
-			this.backClearBtn.Name = "backClearBtn";
-			this.backClearBtn.Click += new System.EventHandler(this.backClearBtn_Click);
-			// 
-			// qlibMenuSeparator1
-			// 
-			this.qlibMenuSeparator1.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.qlibMenuSeparator1.DarkMode = false;
-			this.qlibMenuSeparator1.InsideMenu = true;
-			this.qlibMenuSeparator1.Margin = new System.Windows.Forms.Padding(4);
-			this.qlibMenuSeparator1.Name = "qlibMenuSeparator1";
-			resources.ApplyResources(this.qlibMenuSeparator1, "qlibMenuSeparator1");
-			// 
-			// backCustomBtn
-			// 
-			this.backCustomBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.backCustomBtn.ForeColor = System.Drawing.Color.Black;
-			this.backCustomBtn.Image = global::quick_picture_viewer.Properties.Resources.black_palette;
-			this.backCustomBtn.Name = "backCustomBtn";
-			resources.ApplyResources(this.backCustomBtn, "backCustomBtn");
-			this.backCustomBtn.Click += new System.EventHandler(this.backCustomBtn_Click);
-			// 
-			// onTopButton
-			// 
-			this.onTopButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.onTopButton.ForeColor = System.Drawing.Color.Black;
-			resources.ApplyResources(this.onTopButton, "onTopButton");
-			this.onTopButton.Name = "onTopButton";
-			this.onTopButton.Click += new System.EventHandler(this.onTopButton_Click);
-			// 
-			// framelessBtn
-			// 
-			this.framelessBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.framelessBtn.ForeColor = System.Drawing.Color.Black;
-			resources.ApplyResources(this.framelessBtn, "framelessBtn");
-			this.framelessBtn.Name = "framelessBtn";
-			this.framelessBtn.Click += new System.EventHandler(this.framelessBtn_Click);
-			// 
-			// newWindowButton
-			// 
-			this.newWindowButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.newWindowButton.ForeColor = System.Drawing.Color.Black;
-			this.newWindowButton.Image = global::quick_picture_viewer.Properties.Resources.black_newwindow;
-			this.newWindowButton.Name = "newWindowButton";
-			resources.ApplyResources(this.newWindowButton, "newWindowButton");
-			this.newWindowButton.Click += new System.EventHandler(this.newWindowButton_Click);
-			// 
-			// toolStripSeparator10
-			// 
-			this.toolStripSeparator10.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.toolStripSeparator10.DarkMode = false;
-			this.toolStripSeparator10.InsideMenu = true;
-			this.toolStripSeparator10.Margin = new System.Windows.Forms.Padding(4);
-			this.toolStripSeparator10.Name = "toolStripSeparator10";
-			resources.ApplyResources(this.toolStripSeparator10, "toolStripSeparator10");
-			// 
-			// settingsButton
-			// 
-			this.settingsButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.settingsButton.ForeColor = System.Drawing.Color.Black;
-			resources.ApplyResources(this.settingsButton, "settingsButton");
-			this.settingsButton.Name = "settingsButton";
-			this.settingsButton.Click += new System.EventHandler(this.settingsButton_Click);
-			// 
-			// aboutBtn
-			// 
-			this.aboutBtn.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.aboutBtn.ForeColor = System.Drawing.Color.Black;
-			resources.ApplyResources(this.aboutBtn, "aboutBtn");
-			this.aboutBtn.Name = "aboutBtn";
-			this.aboutBtn.Click += new System.EventHandler(this.aboutButton_Click);
-			// 
-			// framelessCloseBtn
-			// 
-			this.framelessCloseBtn.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			resources.ApplyResources(this.framelessCloseBtn, "framelessCloseBtn");
-			this.framelessCloseBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.framelessCloseBtn.Image = global::quick_picture_viewer.Properties.Resources.black_close;
-			this.framelessCloseBtn.Margin = new System.Windows.Forms.Padding(0);
-			this.framelessCloseBtn.Name = "framelessCloseBtn";
-			this.framelessCloseBtn.Click += new System.EventHandler(this.framelessCloseBtn_Click);
-			// 
-			// picturePanel
-			// 
-			resources.ApplyResources(this.picturePanel, "picturePanel");
-			this.picturePanel.BackColor = System.Drawing.Color.Transparent;
-			this.picturePanel.ContextMenuStrip = this.rmbMenu;
-			this.picturePanel.Controls.Add(this.suggestionIcon);
-			this.picturePanel.Controls.Add(this.suggestionLabel);
-			this.picturePanel.Controls.Add(this.pleaseOpenLabel);
-			this.picturePanel.Controls.Add(this.pictureBox);
-			this.picturePanel.Name = "picturePanel";
-			this.picturePanel.DoubleClick += new System.EventHandler(this.picturePanel_DoubleClick);
-			this.picturePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseDown);
-			this.picturePanel.MouseEnter += new System.EventHandler(this.picturePanel_MouseEnter);
-			this.picturePanel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseMove);
-			this.picturePanel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseUp);
-			// 
-			// rmbMenu
-			// 
-			resources.ApplyResources(this.rmbMenu, "rmbMenu");
-			this.rmbMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.showMenuItem});
-			this.rmbMenu.Name = "rmbMenu";
-			// 
-			// showMenuItem
-			// 
-			this.showMenuItem.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.showMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.backColorBtn.ForeColor = System.Drawing.Color.Black;
+            this.backColorBtn.Image = global::quick_picture_viewer.Properties.Resources.black_palette;
+            this.backColorBtn.Name = "backColorBtn";
+            resources.ApplyResources(this.backColorBtn, "backColorBtn");
+            // 
+            // backClearBtn
+            // 
+            this.backClearBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.backClearBtn.ForeColor = System.Drawing.Color.Black;
+            resources.ApplyResources(this.backClearBtn, "backClearBtn");
+            this.backClearBtn.Name = "backClearBtn";
+            this.backClearBtn.Click += new System.EventHandler(this.backClearBtn_Click);
+            // 
+            // qlibMenuSeparator1
+            // 
+            this.qlibMenuSeparator1.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.qlibMenuSeparator1.DarkMode = false;
+            this.qlibMenuSeparator1.InsideMenu = true;
+            this.qlibMenuSeparator1.Margin = new System.Windows.Forms.Padding(4);
+            this.qlibMenuSeparator1.Name = "qlibMenuSeparator1";
+            resources.ApplyResources(this.qlibMenuSeparator1, "qlibMenuSeparator1");
+            // 
+            // backCustomBtn
+            // 
+            this.backCustomBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.backCustomBtn.ForeColor = System.Drawing.Color.Black;
+            this.backCustomBtn.Image = global::quick_picture_viewer.Properties.Resources.black_palette;
+            this.backCustomBtn.Name = "backCustomBtn";
+            resources.ApplyResources(this.backCustomBtn, "backCustomBtn");
+            this.backCustomBtn.Click += new System.EventHandler(this.backCustomBtn_Click);
+            // 
+            // onTopButton
+            // 
+            this.onTopButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.onTopButton.ForeColor = System.Drawing.Color.Black;
+            resources.ApplyResources(this.onTopButton, "onTopButton");
+            this.onTopButton.Name = "onTopButton";
+            this.onTopButton.Click += new System.EventHandler(this.onTopButton_Click);
+            // 
+            // framelessBtn
+            // 
+            this.framelessBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.framelessBtn.ForeColor = System.Drawing.Color.Black;
+            resources.ApplyResources(this.framelessBtn, "framelessBtn");
+            this.framelessBtn.Name = "framelessBtn";
+            this.framelessBtn.Click += new System.EventHandler(this.framelessBtn_Click);
+            // 
+            // newWindowButton
+            // 
+            this.newWindowButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.newWindowButton.ForeColor = System.Drawing.Color.Black;
+            this.newWindowButton.Image = global::quick_picture_viewer.Properties.Resources.black_newwindow;
+            this.newWindowButton.Name = "newWindowButton";
+            resources.ApplyResources(this.newWindowButton, "newWindowButton");
+            this.newWindowButton.Click += new System.EventHandler(this.newWindowButton_Click);
+            // 
+            // toolStripSeparator10
+            // 
+            this.toolStripSeparator10.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.toolStripSeparator10.DarkMode = false;
+            this.toolStripSeparator10.InsideMenu = true;
+            this.toolStripSeparator10.Margin = new System.Windows.Forms.Padding(4);
+            this.toolStripSeparator10.Name = "toolStripSeparator10";
+            resources.ApplyResources(this.toolStripSeparator10, "toolStripSeparator10");
+            // 
+            // settingsButton
+            // 
+            this.settingsButton.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.settingsButton.ForeColor = System.Drawing.Color.Black;
+            resources.ApplyResources(this.settingsButton, "settingsButton");
+            this.settingsButton.Name = "settingsButton";
+            this.settingsButton.Click += new System.EventHandler(this.settingsButton_Click);
+            // 
+            // aboutBtn
+            // 
+            this.aboutBtn.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.aboutBtn.ForeColor = System.Drawing.Color.Black;
+            resources.ApplyResources(this.aboutBtn, "aboutBtn");
+            this.aboutBtn.Name = "aboutBtn";
+            this.aboutBtn.Click += new System.EventHandler(this.aboutButton_Click);
+            // 
+            // framelessCloseBtn
+            // 
+            this.framelessCloseBtn.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            resources.ApplyResources(this.framelessCloseBtn, "framelessCloseBtn");
+            this.framelessCloseBtn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.framelessCloseBtn.Image = global::quick_picture_viewer.Properties.Resources.black_close;
+            this.framelessCloseBtn.Margin = new System.Windows.Forms.Padding(0);
+            this.framelessCloseBtn.Name = "framelessCloseBtn";
+            this.framelessCloseBtn.Click += new System.EventHandler(this.framelessCloseBtn_Click);
+            // 
+            // showMenuItem
+            // 
+            this.showMenuItem.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.showMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showToolbarBtn,
             this.showStatusBarBtn});
-			resources.ApplyResources(this.showMenuItem, "showMenuItem");
-			this.showMenuItem.ForeColor = System.Drawing.Color.Black;
-			this.showMenuItem.Image = global::quick_picture_viewer.Properties.Resources.black_show;
-			this.showMenuItem.Name = "showMenuItem";
-			this.showMenuItem.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
-			// 
-			// showStatusBarBtn
-			// 
-			this.showStatusBarBtn.Image = global::quick_picture_viewer.Properties.Resources.black_statusbar;
-			this.showStatusBarBtn.Name = "showStatusBarBtn";
-			this.showStatusBarBtn.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
-			resources.ApplyResources(this.showStatusBarBtn, "showStatusBarBtn");
-			this.showStatusBarBtn.Click += new System.EventHandler(this.showStatusBarBtn_Click);
-			// 
-			// suggestionIcon
-			// 
-			this.suggestionIcon.BackColor = System.Drawing.Color.Black;
-			resources.ApplyResources(this.suggestionIcon, "suggestionIcon");
-			this.suggestionIcon.Name = "suggestionIcon";
-			this.suggestionIcon.TabStop = false;
-			// 
-			// suggestionLabel
-			// 
-			resources.ApplyResources(this.suggestionLabel, "suggestionLabel");
-			this.suggestionLabel.BackColor = System.Drawing.Color.Black;
-			this.suggestionLabel.ForeColor = System.Drawing.Color.White;
-			this.suggestionLabel.Name = "suggestionLabel";
-			// 
-			// pleaseOpenLabel
-			// 
-			resources.ApplyResources(this.pleaseOpenLabel, "pleaseOpenLabel");
-			this.pleaseOpenLabel.Name = "pleaseOpenLabel";
-			this.pleaseOpenLabel.DoubleClick += new System.EventHandler(this.picturePanel_DoubleClick);
-			// 
-			// pictureBox
-			// 
-			this.pictureBox.BackColor = System.Drawing.Color.Transparent;
-			resources.ApplyResources(this.pictureBox, "pictureBox");
-			this.pictureBox.Name = "pictureBox";
-			this.pictureBox.TabStop = false;
-			this.pictureBox.DoubleClick += new System.EventHandler(this.picturePanel_DoubleClick);
-			this.pictureBox.MouseDown += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseDown);
-			this.pictureBox.MouseEnter += new System.EventHandler(this.picturePanel_MouseEnter);
-			this.pictureBox.MouseMove += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseMove);
-			this.pictureBox.MouseUp += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseUp);
-			// 
-			// typeOpsButton
-			// 
-			resources.ApplyResources(this.typeOpsButton, "typeOpsButton");
-			this.typeOpsButton.BackColor = System.Drawing.SystemColors.ControlLight;
-			this.typeOpsButton.FlatAppearance.BorderSize = 0;
-			this.typeOpsButton.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.typeOpsButton.Name = "typeOpsButton";
-			this.typeOpsButton.TabStop = false;
-			this.typeOpsButton.UseVisualStyleBackColor = false;
-			this.typeOpsButton.VisibleChanged += new System.EventHandler(this.typeOpsButton_VisibleChanged);
-			this.typeOpsButton.Click += new System.EventHandler(this.typeOpsButton_Click);
-			// 
-			// showToolbarBtn
-			// 
-			this.showToolbarBtn.Image = global::quick_picture_viewer.Properties.Resources.black_toolbar;
-			this.showToolbarBtn.Name = "showToolbarBtn";
-			this.showToolbarBtn.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
-			resources.ApplyResources(this.showToolbarBtn, "showToolbarBtn");
-			this.showToolbarBtn.Click += new System.EventHandler(this.showToolbarBtn_Click);
-			// 
-			// MainForm
-			// 
-			this.AllowDrop = true;
-			resources.ApplyResources(this, "$this");
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-			this.BackColor = System.Drawing.SystemColors.Control;
-			this.Controls.Add(this.typeOpsButton);
-			this.Controls.Add(this.statusStrip1);
-			this.Controls.Add(this.toolStrip1);
-			this.Controls.Add(this.picturePanel);
-			this.KeyPreview = true;
-			this.Name = "MainForm";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
-			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MainForm_FormClosed);
-			this.Load += new System.EventHandler(this.MainForm_Load);
-			this.Shown += new System.EventHandler(this.MainForm_Shown);
-			this.ResizeBegin += new System.EventHandler(this.MainForm_ResizeBegin);
-			this.ResizeEnd += new System.EventHandler(this.MainForm_ResizeEnd);
-			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.MainForm_DragDrop);
-			this.DragEnter += new System.Windows.Forms.DragEventHandler(this.MainForm_DragEnter);
-			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MainForm_KeyDown);
-			((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).EndInit();
-			this.statusStrip1.ResumeLayout(false);
-			this.statusStrip1.PerformLayout();
-			this.toolStrip1.ResumeLayout(false);
-			this.toolStrip1.PerformLayout();
-			this.picturePanel.ResumeLayout(false);
-			this.picturePanel.PerformLayout();
-			this.rmbMenu.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.suggestionIcon)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            resources.ApplyResources(this.showMenuItem, "showMenuItem");
+            this.showMenuItem.ForeColor = System.Drawing.Color.Black;
+            this.showMenuItem.Image = global::quick_picture_viewer.Properties.Resources.black_show;
+            this.showMenuItem.Name = "showMenuItem";
+            this.showMenuItem.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            // 
+            // showToolbarBtn
+            // 
+            this.showToolbarBtn.Image = global::quick_picture_viewer.Properties.Resources.black_toolbar;
+            this.showToolbarBtn.Name = "showToolbarBtn";
+            this.showToolbarBtn.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            resources.ApplyResources(this.showToolbarBtn, "showToolbarBtn");
+            this.showToolbarBtn.Click += new System.EventHandler(this.showToolbarBtn_Click);
+            // 
+            // showStatusBarBtn
+            // 
+            this.showStatusBarBtn.Image = global::quick_picture_viewer.Properties.Resources.black_statusbar;
+            this.showStatusBarBtn.Name = "showStatusBarBtn";
+            this.showStatusBarBtn.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            resources.ApplyResources(this.showStatusBarBtn, "showStatusBarBtn");
+            this.showStatusBarBtn.Click += new System.EventHandler(this.showStatusBarBtn_Click);
+            // 
+            // suggestionIcon
+            // 
+            this.suggestionIcon.BackColor = System.Drawing.Color.Black;
+            resources.ApplyResources(this.suggestionIcon, "suggestionIcon");
+            this.suggestionIcon.Name = "suggestionIcon";
+            this.suggestionIcon.TabStop = false;
+            // 
+            // pictureBox
+            // 
+            this.pictureBox.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.pictureBox, "pictureBox");
+            this.pictureBox.Name = "pictureBox";
+            this.pictureBox.TabStop = false;
+            this.pictureBox.DoubleClick += new System.EventHandler(this.picturePanel_DoubleClick);
+            this.pictureBox.MouseDown += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseDown);
+            this.pictureBox.MouseEnter += new System.EventHandler(this.picturePanel_MouseEnter);
+            this.pictureBox.MouseMove += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseMove);
+            this.pictureBox.MouseUp += new System.Windows.Forms.MouseEventHandler(this.picturePanel_MouseUp);
+            // 
+            // MainForm
+            // 
+            this.AllowDrop = true;
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.Controls.Add(this.typeOpsButton);
+            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.toolStrip1);
+            this.Controls.Add(this.picturePanel);
+            this.KeyPreview = true;
+            this.Name = "MainForm";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MainForm_FormClosed);
+            this.Load += new System.EventHandler(this.MainForm_Load);
+            this.Shown += new System.EventHandler(this.MainForm_Shown);
+            this.ResizeBegin += new System.EventHandler(this.MainForm_ResizeBegin);
+            this.ResizeEnd += new System.EventHandler(this.MainForm_ResizeEnd);
+            this.DragDrop += new System.Windows.Forms.DragEventHandler(this.MainForm_DragDrop);
+            this.DragEnter += new System.Windows.Forms.DragEventHandler(this.MainForm_DragEnter);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MainForm_KeyDown);
+            ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).EndInit();
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            this.toolStrip1.ResumeLayout(false);
+            this.toolStrip1.PerformLayout();
+            this.rmbMenu.ResumeLayout(false);
+            this.picturePanel.ResumeLayout(false);
+            this.picturePanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.suggestionIcon)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -1026,5 +1038,7 @@
 		private System.Windows.Forms.ToolStripMenuItem showMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem showStatusBarBtn;
 		private System.Windows.Forms.ToolStripMenuItem showToolbarBtn;
-	}
+        private System.Windows.Forms.ToolStripButton openFolderButton;
+        private System.Windows.Forms.FolderBrowserDialog openFolderDialog1;
+    }
 }

--- a/quick-picture-viewer/MainForm.cs
+++ b/quick-picture-viewer/MainForm.cs
@@ -24,6 +24,7 @@ namespace quick_picture_viewer
 		private Point panelMouseDownLocation;
 		private bool fullscreen = false;
 		private string currentFolder;
+		private string selectedFolder;
 		private string currentFile;
 		private bool alwaysOnTop = false;
 		private bool imageChanged = false;
@@ -196,6 +197,7 @@ namespace quick_picture_viewer
 			externalChooseBtn.Text = LangMan.Get("open-with-choose") + " ...";
 
 			openButton.Text = LangMan.Get("open-file") + " | Ctrl+O";
+			openFolderButton.Text = LangMan.Get("open-folder") + " | Ctrl+Shift+O";
 			saveAsButton.Text = LangMan.Get("save-as") + " | Ctrl+S";
 			pasteButton.Text = LangMan.Get("paste-image") + " | Ctrl+V";
 			checkboardButton.Text = LangMan.Get("checkboard-background") + " | Ctrl+B";
@@ -266,8 +268,23 @@ namespace quick_picture_viewer
 			if (openFileDialog1.ShowDialog() == DialogResult.OK)
 			{
 				openFile(openFileDialog1.FileName);
+				selectedFolder = null;
 			}
 			openFileDialog1.Dispose();
+		}
+
+		private void openFolderButton_Click(object sender, EventArgs e)
+		{
+			setSlideshow(false);
+
+			openFolderDialog1.Description = LangMan.Get("open-folder");
+
+			if(openFolderDialog1.ShowDialog() == DialogResult.OK)
+            {
+				currentFolder = openFolderDialog1.SelectedPath;
+				selectedFolder = openFolderDialog1.SelectedPath;
+				openFile(getCurrentFiles(true).FirstOrDefault());
+            }
 		}
 
 		private void MainForm_Load(object sender, EventArgs e)
@@ -1272,6 +1289,10 @@ namespace quick_picture_viewer
 						{
 							miniViewButton.PerformClick();
 						}
+						else if (e.KeyCode == Keys.O)
+                        {
+							openFolderButton.PerformClick();
+                        }
 					}
 					else
 					{
@@ -1434,7 +1455,8 @@ namespace quick_picture_viewer
 
 		public int nextFile()
 		{
-			string[] filePaths = getCurrentFiles();
+
+			string[] filePaths = selectedFolder != null ? getCurrentFiles(true) : getCurrentFiles();
 
 			int currentIndex = -1;
 			for (int i = 0; i < filePaths.Length; i++)
@@ -1474,7 +1496,7 @@ namespace quick_picture_viewer
 
 		public void prevFile()
 		{
-			string[] filePaths = getCurrentFiles();
+			string[] filePaths = selectedFolder != null ? getCurrentFiles(true) : getCurrentFiles();
 
 			int currentIndex = -1;
 			for (int i = 0; i < filePaths.Length; i++)
@@ -1508,14 +1530,14 @@ namespace quick_picture_viewer
 			prevFile();
 		}
 
-		private string[] getCurrentFiles()
+		private string[] getCurrentFiles(bool recursive = false)
 		{
 			string[] exts = { ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".exif", ".gif", ".bmp", ".dib", ".rle", ".ico", ".webp", ".svg", ".dds", ".tga", ".psd" };
 			List<string> arlist = new List<string>();
 
 			if (currentFolder != null)
 			{
-				string[] allFiles = Directory.GetFiles(currentFolder);
+				string[] allFiles = recursive ? Directory.GetFiles(selectedFolder, "*", System.IO.SearchOption.AllDirectories) : Directory.GetFiles(currentFolder);
 				for (int i = 0; i < allFiles.Length; i++)
 				{
 					string ext = Path.GetExtension(allFiles[i]).ToLower();
@@ -1677,6 +1699,7 @@ namespace quick_picture_viewer
 				statusStrip1.BackColor = ThemeMan.DarkSecondColor;
 
 				openButton.Image = Properties.Resources.white_open;
+				openFolderButton.Image = Properties.Resources.white_picfolder;
 				saveAsButton.Image = Properties.Resources.white_saveas;
 				printButton.Image = Properties.Resources.white_print;
 				deleteBtn.Image = Properties.Resources.white_trash;
@@ -2467,5 +2490,5 @@ namespace quick_picture_viewer
 			Properties.Settings.Default.ShowToolbar = toolStrip1.Visible;
 			Properties.Settings.Default.Save();
 		}
-	}
+    }
 }

--- a/quick-picture-viewer/MainForm.resx
+++ b/quick-picture-viewer/MainForm.resx
@@ -134,7 +134,7 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>684, 446</value>
+    <value>800, 458</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="typeOpsButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -160,7 +160,7 @@
     <value>NoControl</value>
   </data>
   <data name="typeOpsButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>544, 358</value>
+    <value>660, 370</value>
   </data>
   <data name="typeOpsButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>27, 27, 27, 27</value>
@@ -199,11 +199,130 @@
   <data name="statusStrip1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9.75pt</value>
   </data>
+  <data name="directoryLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAALJJREFUOE/Nks0JAjEQRnPwLihahgpeRQ/amj9YhAcbsABr0DbUClxR0PftBDES
+        ltmTPnhkZtl8E0jC37DGKz7xgXtsopsbdqwMDdzivOycaHIdddolvtHHOnSxsNLwBuziKpI9n00PD3Gt
+        IhswwjOu8IRjFEM8Yr/sjGzABqdWhgkqTLdxwUXsNURkA74ZoCbrBGKGGiJcAVUke/SQWla6aGNyjXrK
+        d1SqR/2bPKRfEcILB30+ElJnYjsAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="directoryLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 17</value>
+  </data>
+  <data name="directoryLabel.Text" xml:space="preserve">
+    <value> folder</value>
+  </data>
+  <data name="directoryLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="fileLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAKVJREFUOE/Nkj0KAjEUBl9rqwiCl7ATxNJLeAqPIXgZrbyLXkAsxUJFUOfbRFhD
+        8mK5A0N+md0i1jk2eMN34gVnWOWBwzD9QZETzpuVgy7m0L7+4IwLbZTwAl+v2ihRCrRx73iH2zj+FRjj
+        Po4p1cAID7jDI06xHasGerhsVmYrfKFiiipeDaRM4qio4m5AD6kfplkGeA/TPHrKT9RXcupsjZ3B7AP8
+        ljJY5GqjGgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="fileLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>45, 17</value>
+  </data>
+  <data name="fileLabel.Text" xml:space="preserve">
+    <value> file</value>
+  </data>
+  <data name="sizeLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAGZJREFUOE/VjzEKgDAQBO9bKtio//+FmvgI3REECRa5KwIOTJFiJ5y14vwwRC9X
+        GQpMcpOddAcY75IxuALlGKoDs2TM7W7ajt83jTJLbq/mCfBzksP9ckBgkaExEDgkkRAESn+B2QXamyDY
+        CyfAWwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="sizeLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 17</value>
+  </data>
+  <data name="sizeLabel.Text" xml:space="preserve">
+    <value> size</value>
+  </data>
+  <data name="zoomLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAALVJREFUOE/V0r8OwVAUgPE7+rt6EBGC6ILRw5hsJJ7EK5DgEcTWxCLETAxWEgPf
+        6bGd9LaVGHzJLz0d2t721v26AiY44oYDxsgjsSK2WKGNyue4xgZyc29TzHU0LSAr8XZCVUdTDfJa3u4o
+        6Wgq46FjfDvUdTQ1sNcxvhGWOprkQyZ+gz5ekF2QleQgT061Cx1cMcAQIZ5I9R/0cIHseea6kItb0VnG
+        5OIzmtHZF80Q6Pg/OfcGzhogaYnUQccAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="zoomLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 17</value>
+  </data>
+  <data name="zoomLabel.Text" xml:space="preserve">
+    <value> zoom</value>
+  </data>
+  <data name="hasChangesLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAO5JREFUOE/N0j1qAlEYheEPiYJgq5B0UQT3YKULsNQuixAxVUSxdAsWNoFoYmGb
+        1h3YmFjZBxHSpUre84k4OOOgjeTAA3MuzJ25P3aNPGKDKdIauCQdfKCEF7zj7EkGWCDrzSyBEebIaCAu
+        +vISt94OucEYr95ORC//ou4tnCK2u8dwnrDCA75QQTB3+ETL21H2a855MytDk9S8md1jjaa3o7Sh3dYX
+        gqlCk+iP9GddROYbhd1jKA1oT06+rLxhCB1VMDoFnUbPW0xSmGGCpAbIfs2RGxYV3TDdtGfkoT3p46Jo
+        Et35H2jdcf5FzP4AA64vkKyV2q0AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="hasChangesLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 17</value>
+  </data>
+  <data name="hasChangesLabel.Text" xml:space="preserve">
+    <value> not-saved</value>
+  </data>
+  <data name="hasChangesLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="dateCreatedLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAANpJREFUOE/F08EKAUEAh/E9kAPClfIeijwN8TZKilxR4gWEB6EIyUU5cxDff3a3
+        1TQ4yVe/ZqY0zc4u7xdVMcUZl2CcoIKPxdHDCjUUkAvGOtboIAZnfcyQNCu/RzCqFBbompWVjr1F2qyi
+        XjdQGexRNquXxtAx7ewNVBMjfxp1gp7VzrVBEUd/GnWDLtFOG4TCErj606h3J3DlPMG7O3DlvAPd6gb2
+        W7DTW9ihZFZWbcyhH7nKYomWWTkKv0S9Zz1OHkpjAwd8/BLD9FENoaPeg3GAr/+Ff+R5T5lgLGc/X8aO
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="dateCreatedLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 17</value>
+  </data>
+  <data name="dateCreatedLabel.Text" xml:space="preserve">
+    <value> created</value>
+  </data>
+  <data name="dateCreatedLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="dateModifiedLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAOZJREFUOE/F08+qAVEAx/EpVzaEnai7sOAZ1I2nId5GKbFHySOg+x63bv6EjbK2
+        IL6/Y6ZmxplrFup+69PMGdNp5pzhvKuqe1QNjLHCCUfMUEdke1TQxxZNFJBHCS38QL9/4KkbzvhGRhfc
+        dN0rjQUGZhRKN8oOZV1w80+gstjgy4xiFJ5AdTB5nL7ONsEn9KSBLkg8TgN5r+afKAWtV6ADtNpxsj7B
+        FNqqOFnXQKv6C/8W2tIurFEzo1A9zKGbbOWwRNeMLCUxhPZZr1OE0rENfaGRX6I/77+gR726xxH+/C/8
+        V45zBz6DLrd6wgPCAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="dateModifiedLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 17</value>
+  </data>
+  <data name="dateModifiedLabel.Text" xml:space="preserve">
+    <value> modified</value>
+  </data>
+  <data name="dateModifiedLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 417</value>
+    <value>0, 429</value>
   </data>
   <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>684, 29</value>
+    <value>800, 29</value>
   </data>
   <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -235,6 +354,876 @@
   <data name="toolStrip1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 10pt</value>
   </data>
+  <data name="openButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="openButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="openButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="openFolderButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="openFolderButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="openFolderButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="saveAsButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="saveAsButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="saveAsButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="saveAsButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="externalBtn.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="externalRunBtn.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="externalRunBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAIlJREFUOE/N
+        jkEOQDAURHsCe9ewZekMVtYcxtUkrJxAXEEkEmZKE361Eha85KV+55tU/Y4KjnARTjCGt3Ax2D5PsGSA
+        iZ48cPEK3kewhykvXPgKjHylE1fBEe/O64LXsN1IWpjBRk92biGDEnaw0JPnR4NsD+G8n0TmFjJ8/AKz
+        WMN8P4nMP0epFfbUMm24gJlIAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="externalRunBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+E</value>
+  </data>
+  <data name="externalRunBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 24</value>
+  </data>
+  <data name="externalRunBtn.Text" xml:space="preserve">
+    <value>open with default</value>
+  </data>
+  <data name="externalFavoriteBtn.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="externalFavoriteBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Shift+O</value>
+  </data>
+  <data name="externalFavoriteBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 24</value>
+  </data>
+  <data name="externalFavoriteBtn.Text" xml:space="preserve">
+    <value>open with custom</value>
+  </data>
+  <data name="externalChooseBtn.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="externalChooseBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACpJREFUOE9j
+        GFTgHRD/h9JkAZBmZBoEQGxcGANQ7AKKwWgYjIbBQAEGBgCbfCwIqrtvVwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="externalChooseBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Shift+E</value>
+  </data>
+  <data name="externalChooseBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 24</value>
+  </data>
+  <data name="externalChooseBtn.Text" xml:space="preserve">
+    <value>choose app</value>
+  </data>
+  <data name="externalBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACJSURBVDhPYxhUwBuI7wHxfzz4LhB7ATFW8AiIHSBMnMAJ
+        iB9AmJgAZAMxAKe6YWSAJhA/B2IQH5tiggaAQAIQk2zAfShtA8TPgDgGiJ+ABNAATgMUgBimGUSDgAaU
+        RgY4DbAGYmTN2IAdEIMSHAZA1iwDxLeBGBYGyBjkJaxJeQEQ20KYdAUMDAA98y+qSrt7WgAAAABJRU5E
+        rkJggg==
+</value>
+  </data>
+  <data name="externalBtn.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="externalBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="externalBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="toolStripSeparator4.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="toolStripSeparator4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1, 24</value>
+  </data>
+  <data name="infoButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="infoButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="infoButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABiSURBVDhPY6Al8Abie0B8F4i9QAKkgkdA7ADETkD8ACRA
+        KngCxDZAbAfEIMNIBiAvPAVikEFkeYEi8B8JfwfidiAmGYA0g4AYEP+AMEkDMANAAJlNNBjpBoA0YMOD
+        DjAwAAAqZh+rNVIgMgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="infoButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="infoButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="prevButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="prevButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="prevButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABVSURBVDhPYxi+wAaIF0KYpAMHIH4JxBZgHonAFojfALET
+        mEciMAVikM1uYB6JgBGILwHxfxIxCtAF4mdA7AXmkQlghviCeWQCfSCm2CUUpYORBRgYAIQzFs78VEtm
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="prevButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="prevButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="slideshowButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="slideshowButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="slideshowButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABtSURBVDhPzY9LCoAwEEPnYAquxfsvBX8L8RCaLEYUDVN/
+        4INH27SkjP2G+YbvcvZD5I5DECALKljDEZYMBLKghQXkeWIAuN9KfF3xoIMZzGHDQCALOMIAe+gj8M51
+        ZEEq3xRcNYnkh4rHBQFmC5UsR8jkx8YmAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="slideshowButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="slideshowButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="nextButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="nextButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="nextButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABaSURBVDhPYxhZYDYQ20OY5AFrIH4FxI5gHpnABYjfAjFF
+        LnEHYpBLzMA8JPCfRHwdiJmBmGQAcsEzIDYE80gEfkD8HIj1wDwSAUjzCyA2APPIABSng+EJGBgAmkEW
+        53y6NbsAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="nextButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="nextButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="showFileButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="showFileButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="showFileButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACYSURBVDhPzZJBCoMwEEWz6L5gsafxeiL0GF6jILT3KYIb
+        LS3Y9w1RIyLjorQPHs4M5ieQuL/hgi32+MYrHtHME1NfugOWmA+dEe28R522wBEN93DGzpeetYAKNX9g
+        psGCaM1aQJjp2+AyxBygE6iuh27CHBDY7L8ScEfNgzecE63RQ0p8aeKE0TXqKb9wvuOW+jd6SL/CuQ8s
+        sUNuvTC3+wAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="showFileButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="showFileButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="toolStripSeparator1.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1, 24</value>
+  </data>
+  <data name="autoZoomButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="autoZoomButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="autoZoomButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABhSURBVDhPY6AW+E8GRgEYAgQA/QzQBOLnQAySR1ZDkoUJ
+        QEy2AdZA/AyIY4H4CUgACjAMeAXEMFvQsS0Qg4AGlAYBkDgKwBCAAqLFRw1gYHgLxCBBdPwGiGEAXW5Q
+        AAYGAEasPsPPKWyEAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="autoZoomButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="autoZoomButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="zoomOutButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="zoomOutButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="zoomOutButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAC0SURBVDhP1dK9DsFQGIfxjj5XFyJCEBaMLsZkI3ElboEE
+        lyA2iUWImRisJAaef1/b4bSVGDzJL307tD3tafDrMhhijwt2GCCNyLJYYY46Cq/jAkvo5t5GmNjoNIVW
+        4u2Aoo1OJei1vF2Rw+ONPG7wtkHZRqcKtjZ+ro+ZjU76kJHfoAMtV7uglaSgJ8fahQbO6KKHNe6I9R+0
+        cYL2PHEt6OJaeJYwXXxENTz7ojGaNv5PQfAE3MIlZG/mLwUAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="zoomOutButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="zoomOutButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="zoomTextBox.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="zoomTextBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9.75pt</value>
+  </data>
+  <data name="zoomTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 24</value>
+  </data>
+  <data name="zoomTextBox.Text" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="zoomTextBox.TextBoxTextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="zoomTextBox.ToolTipText" xml:space="preserve">
+    <value>Zoom</value>
+  </data>
+  <data name="zoomInButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="zoomInButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="zoomInButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAC/SURBVDhP1dJPCwFBHIfxOfp79UIkQlxw9GKc3CivxFug
+        8BLkplxEzuTgSjnwfGdWbcrsrnLw1Kf97WFm1w7z6zIYYo8LdhggjciyWGGOOgrBdYEltLm3ESZutD2C
+        q5pCb+LtgKIbbeENStDP8nZFDlr4Lo8bvG1QdqNNC19VsHXj5/qYudEW3kAfMvIbdKBFOgW9SQp6cqxT
+        aOCMLnpY445Y/4M2TtCZJ64FLa7Zu4Rp8RFVe/dFYzTd+D8Z8wRO6ylgA/HbWwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="zoomInButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="zoomInButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="toolStripSeparator2.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1, 24</value>
+  </data>
+  <data name="editButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="flipHorizontalButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="flipHorizontalButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAHNJREFUOE/NzzEOQEAURdGJhiUplBorsAzLU2gVeq2ClXCF1wzDjEi4yUk0/8F8
+        UYp6ewwrR4t555196D3gOhRnd4dyyPdQ3q9Ah7O3nXGmoR4lIthdDqgMDUZUiKG8BpSGJqxDCYIGlH5t
+        wKMBpS/6RcYsknw8utUbuVkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="flipHorizontalButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+H</value>
+  </data>
+  <data name="flipHorizontalButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>243, 24</value>
+  </data>
+  <data name="flipHorizontalButton.Text" xml:space="preserve">
+    <value>flip horizontal</value>
+  </data>
+  <data name="flipVerticalButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="flipVerticalButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAIhJREFUOE/NktEJhDAQRAOWpaB1iFiqlqFnM3fzjILEzel+CA48dhWZmQTDk6q2
+        WW7TrTGZLjXiG9d18uwSqUcDVwvOvIijAdy+C9JakRrcalGLSRQiNYDLuxhEF1fT4G8L0mdBOrIMINuC
+        9D6uq3IGZgvSP2JPRzkDOLUg3foQWe9d/8WrFcIP3xE8L2HmKDkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="flipVerticalButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Shift+H</value>
+  </data>
+  <data name="flipVerticalButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>243, 24</value>
+  </data>
+  <data name="flipVerticalButton.Text" xml:space="preserve">
+    <value>flip vertical</value>
+  </data>
+  <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>240, 6</value>
+  </data>
+  <data name="rotateRightButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="rotateRightButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAL1JREFUOE/N0r8KglAYh2GX/hENrUXQVbQVQfcSQUPU0GV0I9HQ0NTkFFQEXUGN
+        TQ3R0Fbvz3MG7aiIky88eERQj35eIStjghOeeMDHGCWorj06tXHBGn00rRH20LUebnCq4opZcBbfCl/L
+        aQ49OakO7ki8gfas187dG3WzzFfWGzTwMstoR2TZwhAHs4w2xdYsU9tBc+JUgX7jIjiLbwnNgoYttv9B
+        0mzUMMAGZ7SQWniUP5a+T3iUC5Pn/QDwaSQM+jLsTgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="rotateRightButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+G</value>
+  </data>
+  <data name="rotateRightButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>243, 24</value>
+  </data>
+  <data name="rotateRightButton.Text" xml:space="preserve">
+    <value>rotate right</value>
+  </data>
+  <data name="rotateLeftButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="rotateLeftButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAAMRJREFUOE/N0j8OAUEUgPFt/IsotETiFDoicReRKITCMVxEFAqVaisJInECSpVC
+        FDq+N2+mWJmdbLbhS37xhmSzYyb6q9r2s4AhYtxwxwEjFJHaBR2csMUAdauLJeS3Jry9rYVZ+ZvgjLJZ
+        feUecEVLvkhJ3mSqY75kO/Kf5K6Kp47JHqjpGCz1ATv0dQwmW9jrmEzOeaNjsDXGOiaTSyLnPDcrfzPI
+        MZbMylMDR6zQQwVy5pkukstdZdnny8p0lX9RFH0APGwkDDvDBD0AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="rotateLeftButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Shift+G</value>
+  </data>
+  <data name="rotateLeftButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>243, 24</value>
+  </data>
+  <data name="rotateLeftButton.Text" xml:space="preserve">
+    <value>rotate left</value>
+  </data>
+  <data name="rotate180Button.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="rotate180Button.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAALVJREFUOE/N0jsKwkAYReE0PsDKVtei6xGsxN4VaaO7UBFsfC3CJgqCgp5jUqgz
+        JJa58MEkc4eE5E8qmQaGWOKSW2OEJgrTxRYL9NDK9TGHe3aiqWODyfsqnjHs2A0ywCxbFmYKu0FW8LXL
+        YsdukBtKPxJp45wtv3PH809XBNkjVo45IIgfJkXswCfnwjkJUsMRD8QOyj07dqPp4ASf8nvYe+7ZKYxD
+        4ivu4J+Ra0fZMa9UkuQFGxtJRcKBXbcAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="rotate180Button.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+J</value>
+  </data>
+  <data name="rotate180Button.Size" type="System.Drawing.Size, System.Drawing">
+    <value>243, 24</value>
+  </data>
+  <data name="rotate180Button.Text" xml:space="preserve">
+    <value>rotate 180</value>
+  </data>
+  <data name="customAngleBtn.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="customAngleBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Shift+J</value>
+  </data>
+  <data name="customAngleBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>243, 24</value>
+  </data>
+  <data name="customAngleBtn.Text" xml:space="preserve">
+    <value>custom angle</value>
+  </data>
+  <data name="customAngleBtn.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="editButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADDSURBVDhP1dGxCkFRGMDxUxLZLAYbA5lkMCosNmExyKK8
+        w30Ng8liNJksvAC7gZFiURi8gP93ThlwT+csyr9+db9Tt3vvd9WvqmJqLv1r4oySnjxrQW4u6smzDg4o
+        6Mkzee0Twp5s3UkfR+T09Jl1J1k8sENFDt5qQG4u6+lLAcao4YIVUpCcdrJG3VyqGEaYoAf5rDxCS0Oe
+        GtGTKYMrbDt5NcQGUSQxwBKyE6dfucAdW9wwQxtxOLXHHF0k5OAfUuoJr+Eie9zi9tEAAAAASUVORK5C
+        YII=
+</value>
+  </data>
+  <data name="editButton.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="editButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="editButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="copyButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="copyImageButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="copyImageButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAANZJREFUOE/N
+        0ksLQUEYxvEjisj99gV8UEtSloQFO8VCkoWFJJFsLJQPYoMo/u+MS6c5Mjue+tU7pzlPc07j/E3KOOJm
+        SfaW8MoZUT1aJY6THnWk9VtmmOpRxfWOTcECcz2qfCwIo4OsWn2OZ0EAI+ywRRKSNIbIqZWOZ0ELY0hR
+        FWvkscSzNAGJUVDEBhF5QHxo4IAu/KhBymSPUbBHSq3ekZIm5O+HHus6VjAKCno0Ip8zQB9yCtGDq0Au
+        UkyPngligjbkFBm4LlIFV0irjQtcV/lXcZw75iZGahwH6/4AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="copyImageButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+C</value>
+  </data>
+  <data name="copyImageButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>215, 24</value>
+  </data>
+  <data name="copyImageButton.Text" xml:space="preserve">
+    <value>copy image</value>
+  </data>
+  <data name="copyFileBtn.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="copyFileBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAKVJREFUOE/Nkj0KAjEUBl9rqwiCl7ATxNJLeAqPIXgZrbyLXkAsxUJFUOfbRFhD
+        8mK5A0N+md0i1jk2eMN34gVnWOWBwzD9QZETzpuVgy7m0L7+4IwLbZTwAl+v2ihRCrRx73iH2zj+FRjj
+        Po4p1cAID7jDI06xHasGerhsVmYrfKFiiipeDaRM4qio4m5AD6kfplkGeA/TPHrKT9RXcupsjZ3B7AP8
+        ljJY5GqjGgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="copyFileBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Shift+C</value>
+  </data>
+  <data name="copyFileBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>215, 24</value>
+  </data>
+  <data name="copyFileBtn.Text" xml:space="preserve">
+    <value>copy file</value>
+  </data>
+  <data name="copyButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABmSURBVDhPY6AW6ALi70D8Hw8GybcDMVbwE4hFIUycQAyI
+        f0CYmABkAzEAp2tIMQAEMFxDqgEggKJn1ABIOhCCMHECYSBGDnkUA0Ap8TcQgwRxYZA8ctyDxLACclyD
+        AshxzYABBgYApSo8t1t1S1sAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="copyButton.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="copyButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="copyButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="pasteButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="pasteButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACGSURBVDhPvZLbCYAwDEU7g6BLuJ+OIDiUKA7jCCri48Ya
+        iWkFBeuBQ5Omvf2pCUkGO5jv3QNK2MNVmKqe5gX0MsLYlvthCfcJHGzpIi/xi1JG1hduB4p/A2pI+9oK
+        OtBAMx+rxnc2TMByrJowAfSRIluevAqgrzxBGrKvAny0UAayDfwCYzbNdD10PEP1hgAAAABJRU5ErkJg
+        gg==
+</value>
+  </data>
+  <data name="pasteButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="pasteButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="toolStripSeparator3.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1, 24</value>
+  </data>
+  <data name="checkboardButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="checkboardButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="checkboardButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="fullscreenBtn.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="fullscreenBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAA7SURBVDhPY6AWeAXE/5EwNoAs/xIkgAxwacIFMNQPvAGj
+        gApg4KORYgPeAjFIEIaxAWT5NyCBwQAYGACRRRuVV3VU8gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="fullscreenBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="fullscreenBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="miniViewButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="miniViewButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="miniViewButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABlSURBVDhPYxg0oBOIvwPxfyIxSG0HEMPBTyDmhTCJAvxA
+        /APChACQqaQCFD00M+AdEIPkkDFIDARQ9KBwkAA2cZjYEDGA6DAApQM+CJMogJEOuoH4DxCj24YL/wZi
+        lJQ4ZAEDAwCwsD2tt0DhMgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="miniViewButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="miniViewButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="toolStripSeparator5.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1, 24</value>
+  </data>
+  <data name="effectsBtn.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="pluginManBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>F2</value>
+  </data>
+  <data name="pluginManBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>198, 24</value>
+  </data>
+  <data name="pluginManBtn.Text" xml:space="preserve">
+    <value>plugin manager</value>
+  </data>
+  <data name="effectsBtn.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="effectsBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="effectsBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="toolsBtn.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="pluginManBtn2.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>F2</value>
+  </data>
+  <data name="pluginManBtn2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>198, 24</value>
+  </data>
+  <data name="pluginManBtn2.Text" xml:space="preserve">
+    <value>plugin manager</value>
+  </data>
+  <data name="toolsBtn.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="toolsBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolsBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="qlibToolsep1.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="qlibToolsep1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1, 24</value>
+  </data>
+  <data name="moreButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="reloadButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="reloadButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>F5</value>
+  </data>
+  <data name="reloadButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="reloadButton.Text" xml:space="preserve">
+    <value>reload file</value>
+  </data>
+  <data name="deleteBtn.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="deleteBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Del</value>
+  </data>
+  <data name="deleteBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="deleteBtn.Text" xml:space="preserve">
+    <value>move to trash</value>
+  </data>
+  <data name="printButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="printButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAHRJREFUOE/NkdEKgCAMRf2Gon456Gf6vIoe6s61cAPdXgIPHLyyOUFTl9yOLq2m
+        /wascIfUEJF6F/hxwoljiBkeHBmaSmzvGkHOZNQmSHUA5ZZCmfMbDBx1wSC1Eao3oF+4oL3FInXqVb9Q
+        4g1wkVtqdkVKD1tyPrQ4GpemAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="printButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+P</value>
+  </data>
+  <data name="printButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="printButton.Text" xml:space="preserve">
+    <value>print</value>
+  </data>
+  <data name="setAsDesktopButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="setAsDesktopButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAGRJREFUOE9jGDSgC4i/A/F/IjFIbTsQw8FPIBaFMIkCYkD8A8KEAJCpMBrGJgRQ
+        1FHNAFIAVgNANLGG0cYAUgCGAeRgOAClAyEIkyggDMQo6QCUEn8DMTZbsGGQWpSUOGQBAwMANztAA2Yw
+        a0EAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="setAsDesktopButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Shift+W</value>
+  </data>
+  <data name="setAsDesktopButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="setAsDesktopButton.Text" xml:space="preserve">
+    <value>set as desktop background</value>
+  </data>
+  <data name="qlibMenuSeparator2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>331, 6</value>
+  </data>
+  <data name="actualSizeBtn.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="actualSizeBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAALxJREFUOE/V0r8OAUEQx/Et/InSWwiF0FG4gkTheYRK4U1UEpUoUJ94CURLFGoK
+        4Tu7tpBjLojCL/lkZ3KZ7GV3zS+TQAdrHLFCDxnERoYXmKKE7H0dYgn5rqaLsSsjmaDtytfZIoer7R7X
+        PDa2U3JGCn7QR/o0TrZTIjsU8OwPipCDVdPHyJWRzBB7Bi3Ibv4WkihjjhDqLQQ4oAn/Di6QdyA7q8MN
+        7FG13Zv5ariOHSq2+yAD1Fz5XzHmBoGEJ8a7fZeNAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="actualSizeBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+0</value>
+  </data>
+  <data name="actualSizeBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="actualSizeBtn.Text" xml:space="preserve">
+    <value>zoom to actual size</value>
+  </data>
+  <data name="toolStripSeparator9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>331, 6</value>
+  </data>
+  <data name="backClearBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAO5JREFUOE/N0j1qAlEYheEPiYJgq5B0UQT3YKULsNQuixAxVUSxdAsWNoFoYmGb
+        1h3YmFjZBxHSpUre84k4OOOgjeTAA3MuzJ25P3aNPGKDKdIauCQdfKCEF7zj7EkGWCDrzSyBEebIaCAu
+        +vISt94OucEYr95ORC//ou4tnCK2u8dwnrDCA75QQTB3+ETL21H2a855MytDk9S8md1jjaa3o7Sh3dYX
+        gqlCk+iP9GddROYbhd1jKA1oT06+rLxhCB1VMDoFnUbPW0xSmGGCpAbIfs2RGxYV3TDdtGfkoT3p46Jo
+        Et35H2jdcf5FzP4AA64vkKyV2q0AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="backClearBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+F6</value>
+  </data>
+  <data name="backClearBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 24</value>
+  </data>
+  <data name="backClearBtn.Text" xml:space="preserve">
+    <value>clear</value>
+  </data>
+  <data name="qlibMenuSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>176, 6</value>
+  </data>
+  <data name="backCustomBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>F6</value>
+  </data>
+  <data name="backCustomBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 24</value>
+  </data>
+  <data name="backCustomBtn.Text" xml:space="preserve">
+    <value>choose color</value>
+  </data>
+  <data name="backColorBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="backColorBtn.Text" xml:space="preserve">
+    <value>background color</value>
+  </data>
+  <data name="onTopButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAGFJREFUOE9joDXgg9JkAT8g/gylSQbOQPwKiP8D8Wson2jgC8QgTZZADDIARIP4
+        IHGCQBGIQYodwDyIASDgCMQgcZA8QYCsCGYACBClGR0gG0AWGAYG0B+AnEwIDyrAwAAA9usapRF2XZYA
+        AAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="onTopButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+T</value>
+  </data>
+  <data name="onTopButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="onTopButton.Text" xml:space="preserve">
+    <value>always on top</value>
+  </data>
+  <data name="framelessBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAF1JREFUOE9jGDSgE4i/A/F/IjFIbQcQw8FPIOaFMIkC/ED8A8KEAJCpMJoYDAIw
+        GgywCuIAowbQwwBiMAjAaDAAJSQ+CJMogJGQuoH4DxCj24QL/wZilKQ8UICBAQC3Yk3h8YvbWgAAAABJ
+        RU5ErkJggg==
+</value>
+  </data>
+  <data name="framelessBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>F10</value>
+  </data>
+  <data name="framelessBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="framelessBtn.Text" xml:space="preserve">
+    <value>frameless mode</value>
+  </data>
+  <data name="newWindowButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+N</value>
+  </data>
+  <data name="newWindowButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="newWindowButton.Text" xml:space="preserve">
+    <value>new window</value>
+  </data>
+  <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>331, 6</value>
+  </data>
+  <data name="settingsButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAPRJREFUOE+100FOwkAUxvGBiDcQDWiIHEO8AnID3OoN2GJA2MMNPAIgK93AOYCF
+        qFE8A/y/ea2ZIiZE5Et+yZu2086btm6faWIZaejAtsngGlOUcYUJqtC5X3OLGsZ4giYeRCp4xgi65gaJ
+        5LHAA+pIYT1p3EHXfEJzvtPFo5U+h2hhFlEdLn+IjpUW3e0dJT9yro0ezlHEAPdQLvGGnB8F0bKOrXRz
+        nFrpU8CLle4EH1Ym84UjK/0Twh7P8Gqly0L7lUjcwoUfWQt9aJk6F7agNn+0sGkTdRMtVbbaxJ1eo7LT
+        hxTmz5/yetR3/DPFG/jfcW4F4T49LMAX13oAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="settingsButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Oemcomma</value>
+  </data>
+  <data name="settingsButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="settingsButton.Text" xml:space="preserve">
+    <value>settings</value>
+  </data>
+  <data name="aboutBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAKtJREFUOE/F0jsKwkAURuHZgQa0sTCle9DKSgtXIlgHxTWIrkBQsZYsRxRRSILP
+        wspOzy8WdrkRJAc+JglkuBPi/lUVM0R4YAkfpmpI0EMZBfRxgGmTFYZo4ghN0YI2WSC1O6ZYo4429qgg
+        RmpdBJ9VdbBDCWc9sOYhxAYNDDCHOZ13DI0+go6ka3M3aIotJigiU1c8cXnf5dEJmkD/wk/p5e81c/l/
+        A0POvQA9DCYiD7QYpAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="aboutBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>F1</value>
+  </data>
+  <data name="aboutBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 24</value>
+  </data>
+  <data name="aboutBtn.Text" xml:space="preserve">
+    <value>about</value>
+  </data>
+  <data name="moreButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAhSURBVDhPYxg04D8ZeBSgAWyBRAiPAjSALZAI4eEBGBgA
+        864m2gR2t/kAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="moreButton.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="moreButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="moreButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="framelessCloseBtn.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="framelessCloseBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="framelessCloseBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 25</value>
+  </data>
+  <data name="framelessCloseBtn.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="toolStrip1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
@@ -245,7 +1234,7 @@
     <value>No</value>
   </data>
   <data name="toolStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>684, 32</value>
+    <value>800, 32</value>
   </data>
   <data name="toolStrip1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -299,13 +1288,13 @@
     <value>Segoe UI, 9.75pt</value>
   </data>
   <data name="showMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 24</value>
+    <value>101, 24</value>
   </data>
   <data name="showMenuItem.Text" xml:space="preserve">
     <value>view</value>
   </data>
   <data name="rmbMenu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 50</value>
+    <value>102, 28</value>
   </data>
   <data name="&gt;&gt;rmbMenu.Name" xml:space="preserve">
     <value>rmbMenu</value>
@@ -407,7 +1396,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="pleaseOpenLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>684, 385</value>
+    <value>800, 397</value>
   </data>
   <data name="pleaseOpenLabel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -446,7 +1435,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="pictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>684, 385</value>
+    <value>800, 397</value>
   </data>
   <data name="pictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>Zoom</value>
@@ -473,7 +1462,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="picturePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>684, 385</value>
+    <value>800, 397</value>
   </data>
   <data name="picturePanel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3190,6 +4179,72 @@
   <data name="&gt;&gt;saveFileDialog1.Type" xml:space="preserve">
     <value>System.Windows.Forms.SaveFileDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;printDialog1.Name" xml:space="preserve">
+    <value>printDialog1</value>
+  </data>
+  <data name="&gt;&gt;printDialog1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PrintDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;printDocument1.Name" xml:space="preserve">
+    <value>printDocument1</value>
+  </data>
+  <data name="&gt;&gt;printDocument1.Type" xml:space="preserve">
+    <value>System.Drawing.Printing.PrintDocument, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="&gt;&gt;colorDialog1.Name" xml:space="preserve">
+    <value>colorDialog1</value>
+  </data>
+  <data name="&gt;&gt;colorDialog1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColorDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator4.Name" xml:space="preserve">
+    <value>toolStripSeparator4</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator4.Type" xml:space="preserve">
+    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
+    <value>toolStripSeparator1</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Type" xml:space="preserve">
+    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;zoomTextBox.Name" xml:space="preserve">
+    <value>zoomTextBox</value>
+  </data>
+  <data name="&gt;&gt;zoomTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">
+    <value>toolStripSeparator2</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
+    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator3.Name" xml:space="preserve">
+    <value>toolStripSeparator3</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator3.Type" xml:space="preserve">
+    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator5.Name" xml:space="preserve">
+    <value>toolStripSeparator5</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator5.Type" xml:space="preserve">
+    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;qlibToolsep1.Name" xml:space="preserve">
+    <value>qlibToolsep1</value>
+  </data>
+  <data name="&gt;&gt;qlibToolsep1.Type" xml:space="preserve">
+    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;openFolderDialog1.Name" xml:space="preserve">
+    <value>openFolderDialog1</value>
+  </data>
+  <data name="&gt;&gt;openFolderDialog1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FolderBrowserDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;directoryLabel.Name" xml:space="preserve">
     <value>directoryLabel</value>
   </data>
@@ -3232,28 +4287,16 @@
   <data name="&gt;&gt;dateModifiedLabel.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;printDialog1.Name" xml:space="preserve">
-    <value>printDialog1</value>
-  </data>
-  <data name="&gt;&gt;printDialog1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PrintDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;printDocument1.Name" xml:space="preserve">
-    <value>printDocument1</value>
-  </data>
-  <data name="&gt;&gt;printDocument1.Type" xml:space="preserve">
-    <value>System.Drawing.Printing.PrintDocument, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="&gt;&gt;colorDialog1.Name" xml:space="preserve">
-    <value>colorDialog1</value>
-  </data>
-  <data name="&gt;&gt;colorDialog1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColorDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="&gt;&gt;openButton.Name" xml:space="preserve">
     <value>openButton</value>
   </data>
   <data name="&gt;&gt;openButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;openFolderButton.Name" xml:space="preserve">
+    <value>openFolderButton</value>
+  </data>
+  <data name="&gt;&gt;openFolderButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;saveAsButton.Name" xml:space="preserve">
@@ -3286,12 +4329,6 @@
   <data name="&gt;&gt;externalChooseBtn.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripSeparator4.Name" xml:space="preserve">
-    <value>toolStripSeparator4</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator4.Type" xml:space="preserve">
-    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
   <data name="&gt;&gt;infoButton.Name" xml:space="preserve">
     <value>infoButton</value>
   </data>
@@ -3322,12 +4359,6 @@
   <data name="&gt;&gt;showFileButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
-    <value>toolStripSeparator1</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator1.Type" xml:space="preserve">
-    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
   <data name="&gt;&gt;autoZoomButton.Name" xml:space="preserve">
     <value>autoZoomButton</value>
   </data>
@@ -3340,23 +4371,11 @@
   <data name="&gt;&gt;zoomOutButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;zoomTextBox.Name" xml:space="preserve">
-    <value>zoomTextBox</value>
-  </data>
-  <data name="&gt;&gt;zoomTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="&gt;&gt;zoomInButton.Name" xml:space="preserve">
     <value>zoomInButton</value>
   </data>
   <data name="&gt;&gt;zoomInButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">
-    <value>toolStripSeparator2</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
-    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;editButton.Name" xml:space="preserve">
     <value>editButton</value>
@@ -3430,12 +4449,6 @@
   <data name="&gt;&gt;pasteButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripSeparator3.Name" xml:space="preserve">
-    <value>toolStripSeparator3</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator3.Type" xml:space="preserve">
-    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
   <data name="&gt;&gt;checkboardButton.Name" xml:space="preserve">
     <value>checkboardButton</value>
   </data>
@@ -3453,12 +4466,6 @@
   </data>
   <data name="&gt;&gt;miniViewButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator5.Name" xml:space="preserve">
-    <value>toolStripSeparator5</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator5.Type" xml:space="preserve">
-    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;effectsBtn.Name" xml:space="preserve">
     <value>effectsBtn</value>
@@ -3483,12 +4490,6 @@
   </data>
   <data name="&gt;&gt;pluginManBtn2.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;qlibToolsep1.Name" xml:space="preserve">
-    <value>qlibToolsep1</value>
-  </data>
-  <data name="&gt;&gt;qlibToolsep1.Type" xml:space="preserve">
-    <value>QuickLibrary.QlibToolsep, QuickLibrary, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;moreButton.Name" xml:space="preserve">
     <value>moreButton</value>
@@ -3610,16 +4611,16 @@
   <data name="&gt;&gt;showMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;showStatusBarBtn.Name" xml:space="preserve">
-    <value>showStatusBarBtn</value>
-  </data>
-  <data name="&gt;&gt;showStatusBarBtn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="&gt;&gt;showToolbarBtn.Name" xml:space="preserve">
     <value>showToolbarBtn</value>
   </data>
   <data name="&gt;&gt;showToolbarBtn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showStatusBarBtn.Name" xml:space="preserve">
+    <value>showStatusBarBtn</value>
+  </data>
+  <data name="&gt;&gt;showStatusBarBtn.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
@@ -3634,125 +4635,6 @@
   <data name="saveFileDialog1.Filter" xml:space="preserve">
     <value>PNG (*.png)|*.png|JPEG (*.jpg, *.jpeg, *.jpe, *.jfif, *.exif)|*.jpg|GIF (*.gif)|*.gif|BMP (*.bmp, *.dib, *.rle)|*.bmp|TIFF (*.tiff, *.tif)|*.tiff|ICO (*.ico)|*.ico|WEBP (*.webp)|*.webp</value>
   </data>
-  <data name="directoryLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAALJJREFUOE/Nks0JAjEQRnPwLihahgpeRQ/amj9YhAcbsABr0DbUClxR0PftBDES
-        ltmTPnhkZtl8E0jC37DGKz7xgXtsopsbdqwMDdzivOycaHIdddolvtHHOnSxsNLwBuziKpI9n00PD3Gt
-        IhswwjOu8IRjFEM8Yr/sjGzABqdWhgkqTLdxwUXsNURkA74ZoCbrBGKGGiJcAVUke/SQWla6aGNyjXrK
-        d1SqR/2bPKRfEcILB30+ElJnYjsAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="directoryLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 17</value>
-  </data>
-  <data name="directoryLabel.Text" xml:space="preserve">
-    <value> folder</value>
-  </data>
-  <data name="directoryLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="fileLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAKVJREFUOE/Nkj0KAjEUBl9rqwiCl7ATxNJLeAqPIXgZrbyLXkAsxUJFUOfbRFhD
-        8mK5A0N+md0i1jk2eMN34gVnWOWBwzD9QZETzpuVgy7m0L7+4IwLbZTwAl+v2ihRCrRx73iH2zj+FRjj
-        Po4p1cAID7jDI06xHasGerhsVmYrfKFiiipeDaRM4qio4m5AD6kfplkGeA/TPHrKT9RXcupsjZ3B7AP8
-        ljJY5GqjGgAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="fileLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 17</value>
-  </data>
-  <data name="fileLabel.Text" xml:space="preserve">
-    <value> file</value>
-  </data>
-  <data name="sizeLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAGZJREFUOE/VjzEKgDAQBO9bKtio//+FmvgI3REECRa5KwIOTJFiJ5y14vwwRC9X
-        GQpMcpOddAcY75IxuALlGKoDs2TM7W7ajt83jTJLbq/mCfBzksP9ckBgkaExEDgkkRAESn+B2QXamyDY
-        CyfAWwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="sizeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 17</value>
-  </data>
-  <data name="sizeLabel.Text" xml:space="preserve">
-    <value> size</value>
-  </data>
-  <data name="zoomLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAALVJREFUOE/V0r8OwVAUgPE7+rt6EBGC6ILRw5hsJJ7EK5DgEcTWxCLETAxWEgPf
-        6bGd9LaVGHzJLz0d2t721v26AiY44oYDxsgjsSK2WKGNyue4xgZyc29TzHU0LSAr8XZCVUdTDfJa3u4o
-        6Wgq46FjfDvUdTQ1sNcxvhGWOprkQyZ+gz5ekF2QleQgT061Cx1cMcAQIZ5I9R/0cIHseea6kItb0VnG
-        5OIzmtHZF80Q6Pg/OfcGzhogaYnUQccAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="zoomLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 17</value>
-  </data>
-  <data name="zoomLabel.Text" xml:space="preserve">
-    <value> zoom</value>
-  </data>
-  <data name="hasChangesLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAO5JREFUOE/N0j1qAlEYheEPiYJgq5B0UQT3YKULsNQuixAxVUSxdAsWNoFoYmGb
-        1h3YmFjZBxHSpUre84k4OOOgjeTAA3MuzJ25P3aNPGKDKdIauCQdfKCEF7zj7EkGWCDrzSyBEebIaCAu
-        +vISt94OucEYr95ORC//ou4tnCK2u8dwnrDCA75QQTB3+ETL21H2a855MytDk9S8md1jjaa3o7Sh3dYX
-        gqlCk+iP9GddROYbhd1jKA1oT06+rLxhCB1VMDoFnUbPW0xSmGGCpAbIfs2RGxYV3TDdtGfkoT3p46Jo
-        Et35H2jdcf5FzP4AA64vkKyV2q0AAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="hasChangesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 17</value>
-  </data>
-  <data name="hasChangesLabel.Text" xml:space="preserve">
-    <value> not-saved</value>
-  </data>
-  <data name="hasChangesLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="dateCreatedLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAANpJREFUOE/F08EKAUEAh/E9kAPClfIeijwN8TZKilxR4gWEB6EIyUU5cxDff3a3
-        1TQ4yVe/ZqY0zc4u7xdVMcUZl2CcoIKPxdHDCjUUkAvGOtboIAZnfcyQNCu/RzCqFBbompWVjr1F2qyi
-        XjdQGexRNquXxtAx7ewNVBMjfxp1gp7VzrVBEUd/GnWDLtFOG4TCErj606h3J3DlPMG7O3DlvAPd6gb2
-        W7DTW9ihZFZWbcyhH7nKYomWWTkKv0S9Zz1OHkpjAwd8/BLD9FENoaPeg3GAr/+Ff+R5T5lgLGc/X8aO
-        AAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="dateCreatedLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 17</value>
-  </data>
-  <data name="dateCreatedLabel.Text" xml:space="preserve">
-    <value> created</value>
-  </data>
-  <data name="dateCreatedLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="dateModifiedLabel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAOZJREFUOE/F08+qAVEAx/EpVzaEnai7sOAZ1I2nId5GKbFHySOg+x63bv6EjbK2
-        IL6/Y6ZmxplrFup+69PMGdNp5pzhvKuqe1QNjLHCCUfMUEdke1TQxxZNFJBHCS38QL9/4KkbzvhGRhfc
-        dN0rjQUGZhRKN8oOZV1w80+gstjgy4xiFJ5AdTB5nL7ONsEn9KSBLkg8TgN5r+afKAWtV6ADtNpxsj7B
-        FNqqOFnXQKv6C/8W2tIurFEzo1A9zKGbbOWwRNeMLCUxhPZZr1OE0rENfaGRX6I/77+gR726xxH+/C/8
-        V45zBz6DLrd6wgPCAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="dateModifiedLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
-  </data>
-  <data name="dateModifiedLabel.Text" xml:space="preserve">
-    <value> modified</value>
-  </data>
-  <data name="dateModifiedLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
   <metadata name="printDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>778, 17</value>
   </metadata>
@@ -3762,865 +4644,7 @@
   <metadata name="colorDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1038, 17</value>
   </metadata>
-  <data name="openButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="openButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="openButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="saveAsButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="saveAsButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="saveAsButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="saveAsButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="externalBtn.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="externalBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACJSURBVDhPYxhUwBuI7wHxfzz4LhB7ATFW8AiIHSBMnMAJ
-        iB9AmJgAZAMxAKe6YWSAJhA/B2IQH5tiggaAQAIQk2zAfShtA8TPgDgGiJ+ABNAATgMUgBimGUSDgAaU
-        RgY4DbAGYmTN2IAdEIMSHAZA1iwDxLeBGBYGyBjkJaxJeQEQ20KYdAUMDAA98y+qSrt7WgAAAABJRU5E
-        rkJggg==
-</value>
-  </data>
-  <data name="externalBtn.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="externalBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="externalBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="externalRunBtn.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="externalRunBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAIlJREFUOE/N
-        jkEOQDAURHsCe9ewZekMVtYcxtUkrJxAXEEkEmZKE361Eha85KV+55tU/Y4KjnARTjCGt3Ax2D5PsGSA
-        iZ48cPEK3kewhykvXPgKjHylE1fBEe/O64LXsN1IWpjBRk92biGDEnaw0JPnR4NsD+G8n0TmFjJ8/AKz
-        WMN8P4nMP0epFfbUMm24gJlIAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="externalRunBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+E</value>
-  </data>
-  <data name="externalRunBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 24</value>
-  </data>
-  <data name="externalRunBtn.Text" xml:space="preserve">
-    <value>open with default</value>
-  </data>
-  <data name="externalFavoriteBtn.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="externalFavoriteBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+O</value>
-  </data>
-  <data name="externalFavoriteBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 24</value>
-  </data>
-  <data name="externalFavoriteBtn.Text" xml:space="preserve">
-    <value>open with custom</value>
-  </data>
-  <data name="externalChooseBtn.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="externalChooseBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACpJREFUOE9j
-        GFTgHRD/h9JkAZBmZBoEQGxcGANQ7AKKwWgYjIbBQAEGBgCbfCwIqrtvVwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="externalChooseBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+E</value>
-  </data>
-  <data name="externalChooseBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 24</value>
-  </data>
-  <data name="externalChooseBtn.Text" xml:space="preserve">
-    <value>choose app</value>
-  </data>
-  <data name="toolStripSeparator4.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolStripSeparator4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1, 24</value>
-  </data>
-  <data name="infoButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="infoButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="infoButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABiSURBVDhPY6Al8Abie0B8F4i9QAKkgkdA7ADETkD8ACRA
-        KngCxDZAbAfEIMNIBiAvPAVikEFkeYEi8B8JfwfidiAmGYA0g4AYEP+AMEkDMANAAJlNNBjpBoA0YMOD
-        DjAwAAAqZh+rNVIgMgAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="infoButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="infoButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="prevButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="prevButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="prevButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABVSURBVDhPYxi+wAaIF0KYpAMHIH4JxBZgHonAFojfALET
-        mEciMAVikM1uYB6JgBGILwHxfxIxCtAF4mdA7AXmkQlghviCeWQCfSCm2CUUpYORBRgYAIQzFs78VEtm
-        AAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="prevButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="prevButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="slideshowButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="slideshowButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="slideshowButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABtSURBVDhPzY9LCoAwEEPnYAquxfsvBX8L8RCaLEYUDVN/
-        4INH27SkjP2G+YbvcvZD5I5DECALKljDEZYMBLKghQXkeWIAuN9KfF3xoIMZzGHDQCALOMIAe+gj8M51
-        ZEEq3xRcNYnkh4rHBQFmC5UsR8jkx8YmAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="slideshowButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="slideshowButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="nextButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="nextButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="nextButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABaSURBVDhPYxhZYDYQ20OY5AFrIH4FxI5gHpnABYjfAjFF
-        LnEHYpBLzMA8JPCfRHwdiJmBmGQAcsEzIDYE80gEfkD8HIj1wDwSAUjzCyA2APPIABSng+EJGBgAmkEW
-        53y6NbsAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="nextButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="nextButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="showFileButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="showFileButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="showFileButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACYSURBVDhPzZJBCoMwEEWz6L5gsafxeiL0GF6jILT3KYIb
-        LS3Y9w1RIyLjorQPHs4M5ieQuL/hgi32+MYrHtHME1NfugOWmA+dEe28R522wBEN93DGzpeetYAKNX9g
-        psGCaM1aQJjp2+AyxBygE6iuh27CHBDY7L8ScEfNgzecE63RQ0p8aeKE0TXqKb9wvuOW+jd6SL/CuQ8s
-        sUNuvTC3+wAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="showFileButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="showFileButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="toolStripSeparator1.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1, 24</value>
-  </data>
-  <data name="autoZoomButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="autoZoomButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="autoZoomButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABhSURBVDhPY6AW+E8GRgEYAgQA/QzQBOLnQAySR1ZDkoUJ
-        QEy2AdZA/AyIY4H4CUgACjAMeAXEMFvQsS0Qg4AGlAYBkDgKwBCAAqLFRw1gYHgLxCBBdPwGiGEAXW5Q
-        AAYGAEasPsPPKWyEAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="autoZoomButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="autoZoomButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="zoomOutButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="zoomOutButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="zoomOutButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAC0SURBVDhP1dK9DsFQGIfxjj5XFyJCEBaMLsZkI3ElboEE
-        lyA2iUWImRisJAaef1/b4bSVGDzJL307tD3tafDrMhhijwt2GCCNyLJYYY46Cq/jAkvo5t5GmNjoNIVW
-        4u2Aoo1OJei1vF2Rw+ONPG7wtkHZRqcKtjZ+ro+ZjU76kJHfoAMtV7uglaSgJ8fahQbO6KKHNe6I9R+0
-        cYL2PHEt6OJaeJYwXXxENTz7ojGaNv5PQfAE3MIlZG/mLwUAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="zoomOutButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="zoomOutButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="zoomTextBox.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="zoomTextBox.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9.75pt</value>
-  </data>
-  <data name="zoomTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 24</value>
-  </data>
-  <data name="zoomTextBox.Text" xml:space="preserve">
-    <value>Auto</value>
-  </data>
-  <data name="zoomTextBox.TextBoxTextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="zoomTextBox.ToolTipText" xml:space="preserve">
-    <value>Zoom</value>
-  </data>
-  <data name="zoomInButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="zoomInButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="zoomInButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAC/SURBVDhP1dJPCwFBHIfxOfp79UIkQlxw9GKc3CivxFug
-        8BLkplxEzuTgSjnwfGdWbcrsrnLw1Kf97WFm1w7z6zIYYo8LdhggjciyWGGOOgrBdYEltLm3ESZutD2C
-        q5pCb+LtgKIbbeENStDP8nZFDlr4Lo8bvG1QdqNNC19VsHXj5/qYudEW3kAfMvIbdKBFOgW9SQp6cqxT
-        aOCMLnpY445Y/4M2TtCZJ64FLa7Zu4Rp8RFVe/dFYzTd+D8Z8wRO6ylgA/HbWwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="zoomInButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="zoomInButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="toolStripSeparator2.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1, 24</value>
-  </data>
-  <data name="editButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="editButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADDSURBVDhP1dGxCkFRGMDxUxLZLAYbA5lkMCosNmExyKK8
-        w30Ng8liNJksvAC7gZFiURi8gP93ThlwT+csyr9+db9Tt3vvd9WvqmJqLv1r4oySnjxrQW4u6smzDg4o
-        6Mkzee0Twp5s3UkfR+T09Jl1J1k8sENFDt5qQG4u6+lLAcao4YIVUpCcdrJG3VyqGEaYoAf5rDxCS0Oe
-        GtGTKYMrbDt5NcQGUSQxwBKyE6dfucAdW9wwQxtxOLXHHF0k5OAfUuoJr+Eie9zi9tEAAAAASUVORK5C
-        YII=
-</value>
-  </data>
-  <data name="editButton.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="editButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="editButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="flipHorizontalButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="flipHorizontalButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAHNJREFUOE/NzzEOQEAURdGJhiUplBorsAzLU2gVeq2ClXCF1wzDjEi4yUk0/8F8
-        UYp6ewwrR4t555196D3gOhRnd4dyyPdQ3q9Ah7O3nXGmoR4lIthdDqgMDUZUiKG8BpSGJqxDCYIGlH5t
-        wKMBpS/6RcYsknw8utUbuVkAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="flipHorizontalButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+H</value>
-  </data>
-  <data name="flipHorizontalButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
-  </data>
-  <data name="flipHorizontalButton.Text" xml:space="preserve">
-    <value>flip horizontal</value>
-  </data>
-  <data name="flipVerticalButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="flipVerticalButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAIhJREFUOE/NktEJhDAQRAOWpaB1iFiqlqFnM3fzjILEzel+CA48dhWZmQTDk6q2
-        WW7TrTGZLjXiG9d18uwSqUcDVwvOvIijAdy+C9JakRrcalGLSRQiNYDLuxhEF1fT4G8L0mdBOrIMINuC
-        9D6uq3IGZgvSP2JPRzkDOLUg3foQWe9d/8WrFcIP3xE8L2HmKDkAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="flipVerticalButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+H</value>
-  </data>
-  <data name="flipVerticalButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
-  </data>
-  <data name="flipVerticalButton.Text" xml:space="preserve">
-    <value>flip vertical</value>
-  </data>
-  <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>240, 6</value>
-  </data>
-  <data name="rotateRightButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="rotateRightButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAL1JREFUOE/N0r8KglAYh2GX/hENrUXQVbQVQfcSQUPU0GV0I9HQ0NTkFFQEXUGN
-        TQ3R0Fbvz3MG7aiIky88eERQj35eIStjghOeeMDHGCWorj06tXHBGn00rRH20LUebnCq4opZcBbfCl/L
-        aQ49OakO7ki8gfas187dG3WzzFfWGzTwMstoR2TZwhAHs4w2xdYsU9tBc+JUgX7jIjiLbwnNgoYttv9B
-        0mzUMMAGZ7SQWniUP5a+T3iUC5Pn/QDwaSQM+jLsTgAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="rotateRightButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+G</value>
-  </data>
-  <data name="rotateRightButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
-  </data>
-  <data name="rotateRightButton.Text" xml:space="preserve">
-    <value>rotate right</value>
-  </data>
-  <data name="rotateLeftButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="rotateLeftButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAMRJREFUOE/N0j8OAUEUgPFt/IsotETiFDoicReRKITCMVxEFAqVaisJInECSpVC
-        FDq+N2+mWJmdbLbhS37xhmSzYyb6q9r2s4AhYtxwxwEjFJHaBR2csMUAdauLJeS3Jry9rYVZ+ZvgjLJZ
-        feUecEVLvkhJ3mSqY75kO/Kf5K6Kp47JHqjpGCz1ATv0dQwmW9jrmEzOeaNjsDXGOiaTSyLnPDcrfzPI
-        MZbMylMDR6zQQwVy5pkukstdZdnny8p0lX9RFH0APGwkDDvDBD0AAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="rotateLeftButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+G</value>
-  </data>
-  <data name="rotateLeftButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
-  </data>
-  <data name="rotateLeftButton.Text" xml:space="preserve">
-    <value>rotate left</value>
-  </data>
-  <data name="rotate180Button.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="rotate180Button.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAALVJREFUOE/N0jsKwkAYReE0PsDKVtei6xGsxN4VaaO7UBFsfC3CJgqCgp5jUqgz
-        JJa58MEkc4eE5E8qmQaGWOKSW2OEJgrTxRYL9NDK9TGHe3aiqWODyfsqnjHs2A0ywCxbFmYKu0FW8LXL
-        YsdukBtKPxJp45wtv3PH809XBNkjVo45IIgfJkXswCfnwjkJUsMRD8QOyj07dqPp4ASf8nvYe+7ZKYxD
-        4ivu4J+Ra0fZMa9UkuQFGxtJRcKBXbcAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="rotate180Button.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+J</value>
-  </data>
-  <data name="rotate180Button.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
-  </data>
-  <data name="rotate180Button.Text" xml:space="preserve">
-    <value>rotate 180</value>
-  </data>
-  <data name="customAngleBtn.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="customAngleBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+J</value>
-  </data>
-  <data name="customAngleBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
-  </data>
-  <data name="customAngleBtn.Text" xml:space="preserve">
-    <value>custom angle</value>
-  </data>
-  <data name="customAngleBtn.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="copyButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="copyButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABmSURBVDhPY6AW6ALi70D8Hw8GybcDMVbwE4hFIUycQAyI
-        f0CYmABkAzEAp2tIMQAEMFxDqgEggKJn1ABIOhCCMHECYSBGDnkUA0Ap8TcQgwRxYZA8ctyDxLACclyD
-        AshxzYABBgYApSo8t1t1S1sAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="copyButton.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="copyButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="copyButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="copyImageButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="copyImageButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAANZJREFUOE/N
-        0ksLQUEYxvEjisj99gV8UEtSloQFO8VCkoWFJJFsLJQPYoMo/u+MS6c5Mjue+tU7pzlPc07j/E3KOOJm
-        SfaW8MoZUT1aJY6THnWk9VtmmOpRxfWOTcECcz2qfCwIo4OsWn2OZ0EAI+ywRRKSNIbIqZWOZ0ELY0hR
-        FWvkscSzNAGJUVDEBhF5QHxo4IAu/KhBymSPUbBHSq3ekZIm5O+HHus6VjAKCno0Ip8zQB9yCtGDq0Au
-        UkyPngligjbkFBm4LlIFV0irjQtcV/lXcZw75iZGahwH6/4AAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="copyImageButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+C</value>
-  </data>
-  <data name="copyImageButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>215, 24</value>
-  </data>
-  <data name="copyImageButton.Text" xml:space="preserve">
-    <value>copy image</value>
-  </data>
-  <data name="copyFileBtn.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="copyFileBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAKVJREFUOE/Nkj0KAjEUBl9rqwiCl7ATxNJLeAqPIXgZrbyLXkAsxUJFUOfbRFhD
-        8mK5A0N+md0i1jk2eMN34gVnWOWBwzD9QZETzpuVgy7m0L7+4IwLbZTwAl+v2ihRCrRx73iH2zj+FRjj
-        Po4p1cAID7jDI06xHasGerhsVmYrfKFiiipeDaRM4qio4m5AD6kfplkGeA/TPHrKT9RXcupsjZ3B7AP8
-        ljJY5GqjGgAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="copyFileBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+C</value>
-  </data>
-  <data name="copyFileBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>215, 24</value>
-  </data>
-  <data name="copyFileBtn.Text" xml:space="preserve">
-    <value>copy file</value>
-  </data>
-  <data name="pasteButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="pasteButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACGSURBVDhPvZLbCYAwDEU7g6BLuJ+OIDiUKA7jCCri48Ya
-        iWkFBeuBQ5Omvf2pCUkGO5jv3QNK2MNVmKqe5gX0MsLYlvthCfcJHGzpIi/xi1JG1hduB4p/A2pI+9oK
-        OtBAMx+rxnc2TMByrJowAfSRIluevAqgrzxBGrKvAny0UAayDfwCYzbNdD10PEP1hgAAAABJRU5ErkJg
-        gg==
-</value>
-  </data>
-  <data name="pasteButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="pasteButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="toolStripSeparator3.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1, 24</value>
-  </data>
-  <data name="checkboardButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="checkboardButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="checkboardButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="fullscreenBtn.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="fullscreenBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAA7SURBVDhPY6AWeAXE/5EwNoAs/xIkgAxwacIFMNQPvAGj
-        gApg4KORYgPeAjFIEIaxAWT5NyCBwQAYGACRRRuVV3VU8gAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="fullscreenBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="fullscreenBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="miniViewButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="miniViewButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="miniViewButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABlSURBVDhPYxg0oBOIvwPxfyIxSG0HEMPBTyDmhTCJAvxA
-        /APChACQqaQCFD00M+AdEIPkkDFIDARQ9KBwkAA2cZjYEDGA6DAApQM+CJMogJEOuoH4DxCj24YL/wZi
-        lJQ4ZAEDAwCwsD2tt0DhMgAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="miniViewButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="miniViewButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="toolStripSeparator5.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1, 24</value>
-  </data>
-  <data name="effectsBtn.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="effectsBtn.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="effectsBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="effectsBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="pluginManBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>F2</value>
-  </data>
-  <data name="pluginManBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>198, 24</value>
-  </data>
-  <data name="pluginManBtn.Text" xml:space="preserve">
-    <value>plugin manager</value>
-  </data>
-  <data name="toolsBtn.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolsBtn.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="toolsBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolsBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="pluginManBtn2.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>F2</value>
-  </data>
-  <data name="pluginManBtn2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>198, 24</value>
-  </data>
-  <data name="pluginManBtn2.Text" xml:space="preserve">
-    <value>plugin manager</value>
-  </data>
-  <data name="qlibToolsep1.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="qlibToolsep1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1, 24</value>
-  </data>
-  <data name="moreButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="moreButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAhSURBVDhPYxg04D8ZeBSgAWyBRAiPAjSALZAI4eEBGBgA
-        864m2gR2t/kAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="moreButton.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="moreButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="moreButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="reloadButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="reloadButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>F5</value>
-  </data>
-  <data name="reloadButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="reloadButton.Text" xml:space="preserve">
-    <value>reload file</value>
-  </data>
-  <data name="deleteBtn.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="deleteBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Del</value>
-  </data>
-  <data name="deleteBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="deleteBtn.Text" xml:space="preserve">
-    <value>move to trash</value>
-  </data>
-  <data name="printButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="printButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAHRJREFUOE/NkdEKgCAMRf2Gon456Gf6vIoe6s61cAPdXgIPHLyyOUFTl9yOLq2m
-        /wascIfUEJF6F/hxwoljiBkeHBmaSmzvGkHOZNQmSHUA5ZZCmfMbDBx1wSC1Eao3oF+4oL3FInXqVb9Q
-        4g1wkVtqdkVKD1tyPrQ4GpemAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="printButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+P</value>
-  </data>
-  <data name="printButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="printButton.Text" xml:space="preserve">
-    <value>print</value>
-  </data>
-  <data name="setAsDesktopButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="setAsDesktopButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAGRJREFUOE9jGDSgC4i/A/F/IjFIbTsQw8FPIBaFMIkCYkD8A8KEAJCpMBrGJgRQ
-        1FHNAFIAVgNANLGG0cYAUgCGAeRgOAClAyEIkyggDMQo6QCUEn8DMTZbsGGQWpSUOGQBAwMANztAA2Yw
-        a0EAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="setAsDesktopButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+W</value>
-  </data>
-  <data name="setAsDesktopButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="setAsDesktopButton.Text" xml:space="preserve">
-    <value>set as desktop background</value>
-  </data>
-  <data name="qlibMenuSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>331, 6</value>
-  </data>
-  <data name="actualSizeBtn.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="actualSizeBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAALxJREFUOE/V0r8OAUEQx/Et/InSWwiF0FG4gkTheYRK4U1UEpUoUJ94CURLFGoK
-        4Tu7tpBjLojCL/lkZ3KZ7GV3zS+TQAdrHLFCDxnERoYXmKKE7H0dYgn5rqaLsSsjmaDtytfZIoer7R7X
-        PDa2U3JGCn7QR/o0TrZTIjsU8OwPipCDVdPHyJWRzBB7Bi3Ibv4WkihjjhDqLQQ4oAn/Di6QdyA7q8MN
-        7FG13Zv5ariOHSq2+yAD1Fz5XzHmBoGEJ8a7fZeNAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="actualSizeBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+0</value>
-  </data>
-  <data name="actualSizeBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="actualSizeBtn.Text" xml:space="preserve">
-    <value>zoom to actual size</value>
-  </data>
-  <data name="toolStripSeparator9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>331, 6</value>
-  </data>
-  <data name="backColorBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="backColorBtn.Text" xml:space="preserve">
-    <value>background color</value>
-  </data>
-  <data name="backClearBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAO5JREFUOE/N0j1qAlEYheEPiYJgq5B0UQT3YKULsNQuixAxVUSxdAsWNoFoYmGb
-        1h3YmFjZBxHSpUre84k4OOOgjeTAA3MuzJ25P3aNPGKDKdIauCQdfKCEF7zj7EkGWCDrzSyBEebIaCAu
-        +vISt94OucEYr95ORC//ou4tnCK2u8dwnrDCA75QQTB3+ETL21H2a855MytDk9S8md1jjaa3o7Sh3dYX
-        gqlCk+iP9GddROYbhd1jKA1oT06+rLxhCB1VMDoFnUbPW0xSmGGCpAbIfs2RGxYV3TDdtGfkoT3p46Jo
-        Et35H2jdcf5FzP4AA64vkKyV2q0AAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="backClearBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+F6</value>
-  </data>
-  <data name="backClearBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 24</value>
-  </data>
-  <data name="backClearBtn.Text" xml:space="preserve">
-    <value>clear</value>
-  </data>
-  <data name="qlibMenuSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 6</value>
-  </data>
-  <data name="backCustomBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>F6</value>
-  </data>
-  <data name="backCustomBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 24</value>
-  </data>
-  <data name="backCustomBtn.Text" xml:space="preserve">
-    <value>choose color</value>
-  </data>
-  <data name="onTopButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAGFJREFUOE9joDXgg9JkAT8g/gylSQbOQPwKiP8D8Wson2jgC8QgTZZADDIARIP4
-        IHGCQBGIQYodwDyIASDgCMQgcZA8QYCsCGYACBClGR0gG0AWGAYG0B+AnEwIDyrAwAAA9usapRF2XZYA
-        AAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="onTopButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+T</value>
-  </data>
-  <data name="onTopButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="onTopButton.Text" xml:space="preserve">
-    <value>always on top</value>
-  </data>
-  <data name="framelessBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAF1JREFUOE9jGDSgE4i/A/F/IjFIbQcQw8FPIOaFMIkC/ED8A8KEAJCpMJoYDAIw
-        GgywCuIAowbQwwBiMAjAaDAAJSQ+CJMogJGQuoH4DxCj24QL/wZilKQ8UICBAQC3Yk3h8YvbWgAAAABJ
-        RU5ErkJggg==
-</value>
-  </data>
-  <data name="framelessBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>F10</value>
-  </data>
-  <data name="framelessBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="framelessBtn.Text" xml:space="preserve">
-    <value>frameless mode</value>
-  </data>
-  <data name="newWindowButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+N</value>
-  </data>
-  <data name="newWindowButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="newWindowButton.Text" xml:space="preserve">
-    <value>new window</value>
-  </data>
-  <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>331, 6</value>
-  </data>
-  <data name="settingsButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAPRJREFUOE+100FOwkAUxvGBiDcQDWiIHEO8AnID3OoN2GJA2MMNPAIgK93AOYCF
-        qFE8A/y/ea2ZIiZE5Et+yZu2086btm6faWIZaejAtsngGlOUcYUJqtC5X3OLGsZ4giYeRCp4xgi65gaJ
-        5LHAA+pIYT1p3EHXfEJzvtPFo5U+h2hhFlEdLn+IjpUW3e0dJT9yro0ezlHEAPdQLvGGnB8F0bKOrXRz
-        nFrpU8CLle4EH1Ym84UjK/0Twh7P8Gqly0L7lUjcwoUfWQt9aJk6F7agNn+0sGkTdRMtVbbaxJ1eo7LT
-        hxTmz5/yetR3/DPFG/jfcW4F4T49LMAX13oAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="settingsButton.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Oemcomma</value>
-  </data>
-  <data name="settingsButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="settingsButton.Text" xml:space="preserve">
-    <value>settings</value>
-  </data>
-  <data name="aboutBtn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAKtJREFUOE/F0jsKwkAURuHZgQa0sTCle9DKSgtXIlgHxTWIrkBQsZYsRxRRSILP
-        wspOzy8WdrkRJAc+JglkuBPi/lUVM0R4YAkfpmpI0EMZBfRxgGmTFYZo4ghN0YI2WSC1O6ZYo4429qgg
-        RmpdBJ9VdbBDCWc9sOYhxAYNDDCHOZ13DI0+go6ka3M3aIotJigiU1c8cXnf5dEJmkD/wk/p5e81c/l/
-        A0POvQA9DCYiD7QYpAAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="aboutBtn.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>F1</value>
-  </data>
-  <data name="aboutBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 24</value>
-  </data>
-  <data name="aboutBtn.Text" xml:space="preserve">
-    <value>about</value>
-  </data>
-  <data name="framelessCloseBtn.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="framelessCloseBtn.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="framelessCloseBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 25</value>
-  </data>
-  <data name="framelessCloseBtn.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
+  <metadata name="openFolderDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1159, 17</value>
+  </metadata>
 </root>

--- a/quick-picture-viewer/Properties/Resources.Designer.cs
+++ b/quick-picture-viewer/Properties/Resources.Designer.cs
@@ -173,6 +173,16 @@ namespace quick_picture_viewer.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap black_picfolder {
+            get {
+                object obj = ResourceManager.GetObject("black_picfolder", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap black_plugin {
             get {
                 object obj = ResourceManager.GetObject("black_plugin", resourceCulture);

--- a/quick-picture-viewer/Properties/Resources.resx
+++ b/quick-picture-viewer/Properties/Resources.resx
@@ -376,4 +376,7 @@
   <data name="white_toolbar" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\imgs\light\white-toolbar.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="black_picfolder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\imgs\dark\black-picfolder.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/quick-picture-viewer/bin/Debug/languages/lang_en.resx
+++ b/quick-picture-viewer/bin/Debug/languages/lang_en.resx
@@ -533,6 +533,10 @@
     <value>Open file</value>
     <comment>Menu</comment>
   </data>
+  <data name="open-folder" xml:space="preserve">
+    <value>Open folder recursively</value>
+    <comment>Menu</comment>
+  </data>
   <data name="open-windows-settings" xml:space="preserve">
     <value>Open Windows settings</value>
     <comment>About</comment>

--- a/quick-picture-viewer/languages/lang_en.resx
+++ b/quick-picture-viewer/languages/lang_en.resx
@@ -533,6 +533,10 @@
     <value>Open file</value>
     <comment>Menu</comment>
   </data>
+  <data name="open-folder" xml:space="preserve">
+    <value>Open folder recursively</value>
+    <comment>Menu</comment>
+  </data>
   <data name="open-windows-settings" xml:space="preserve">
     <value>Open Windows settings</value>
     <comment>About</comment>

--- a/quick-picture-viewer/quick-picture-viewer.csproj
+++ b/quick-picture-viewer/quick-picture-viewer.csproj
@@ -402,6 +402,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="picture.ico" />
+    <None Include="resources\imgs\dark\black-picfolder.png" />
     <None Include="resources\imgs\light\white-statusbar.png" />
     <None Include="resources\imgs\light\white-toolbar.png" />
     <None Include="resources\imgs\dark\black-toolbar.png" />


### PR DESCRIPTION
I added the option to open a folder recursively because I needed it for personal use, but I thought that I might as well make a PR for it in case you think it's a good idea.

#### Potential improvements:
- Add the `Microsoft.WindowsAPICodePack-Shell` package so we can use `CommonOpenFileDialog` with the `IsFolderPicker` property set instead of the awful FolderBrowserDialog. I didn't want to do this without asking since it requires a package to be added.
- Change the "Open file" button to a `ToolStripSplitButton` and add the recursive option under it. I tried this approach but the dark mode theming didn't seem to work properly with the split button, so I abandoned the idea as I have never worked with Windows Forms before.

I would rebase from master, but the conflicts in the resx files scare me and I haven't worked with Windows Forms before.