### PR TITLE
Fixed README cloning steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,20 +112,18 @@ scoop install quick-picture-viewer
 
 #### How to clone:
 
-1. Clone:
-
+When cloning the repository, do **not** forget to include its submodules (`--recurse-submodules`):
 ```powershell
-git clone --recurse-submodules https://github.com/ModuleArt/qpv-plugins
+git clone --recurse-submodules https://github.com/ModuleArt/quick-picture-viewer
 ```
 
-2. Download submodules:
-
+Otherwise, you can initialize them after cloning:
+```powershell
+git clone https://github.com/ModuleArt/quick-picture-viewer
+cd quick-picture-viewer
+git submodule update --init --recursive
 ```
-git submodule init
-git submodule update
-```
 
-3. Build submodules.
 
 #### Code contributors:
 


### PR DESCRIPTION
### User Problem  
The README currently references the wrong repository (`qpv-plugins` instead of `quick-picture-viewer`) in the cloning steps. Additionally, the instructions for cloning submodules are unclear, potentially causing confusion for users.

### Proposed Changes  
- Corrected the repository URL in the README to point to `quick-picture-viewer`.  
- Clarified the steps to clone the repository, explicitly covering scenarios with and without submodules.  

These updates ensure that users can follow the instructions without encountering errors, improving the overall developer experience.